### PR TITLE
An HTML5 version of math4ml

### DIFF
--- a/LaTeXML-maybeMathjax.js
+++ b/LaTeXML-maybeMathjax.js
@@ -1,0 +1,34 @@
+//======================================================================
+// Load MathJax, IFF the current browser can't handle MathML natively.
+
+(function() {
+    var mathjax_url =
+        "https://cdn.jsdelivr.net/npm/mathjax@3/es5/mml-chtml.js";
+
+    function refreshMath() {
+        // Maybe unnecessary, or overkill, but...
+        if (typeof MathJax != "undefined") {
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+        }
+    }
+
+    // Add script element loading MathJax unless we can handle MathML
+    var agent = navigator.userAgent;
+    var is_gecko = (agent.indexOf("Gecko") > -1 &&
+                    agent.indexOf("KHTML") === -1 &&
+                    agent.indexOf("Trident") === -1);
+    // Check for MathPlayer, but only IE's before IE 10 when it was disabled.
+    var has_mathplayer = (agent.indexOf("MathPlayer") > -1 &&
+                    agent.indexOf("rv:1") === -1); /* till ie 20! */
+    if (!is_gecko && !has_mathplayer) {
+        var head = document.getElementsByTagName("head")[0];
+        if (head != null) {
+            var script = document.createElement("script");
+            script.type = "text/javascript";
+            script.src = mathjax_url;
+            script.onreadystatechange = refreshMath;
+            script.onload = refreshMath;
+            head.appendChild(script);
+        }
+    }
+}());

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3857 @@
+<!DOCTYPE html><html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Mathematics for Machine Learning</title>
+<!--Generated on Tue Dec 21 16:14:08 2021 by LaTeXML (version 0.8.6) http://dlmf.nist.gov/LaTeXML/.-->
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.5.6/css/ar5iv.min.css" type="text/css">
+<script src="LaTeXML-maybeMathjax.js" type="text/javascript"></script>
+</head>
+<body>
+<div class="ltx_page_main">
+<div class="ltx_page_content">
+<article class="ltx_document ltx_authors_1line">
+<h1 class="ltx_title ltx_title_document">Mathematics for Machine Learning</h1>
+<div class="ltx_authors">
+<span class="ltx_creator ltx_role_author">
+<span class="ltx_personname">Garrett Thomas
+<br class="ltx_break">Department of Electrical Engineering and Computer Sciences
+<br class="ltx_break">University of California, Berkeley
+</span></span>
+</div>
+
+<section id="S1" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">
+<span class="ltx_tag ltx_tag_section">1 </span>About</h2>
+
+<div id="S1.p1" class="ltx_para ltx_noindent">
+<p id="S1.p1.1" class="ltx_p">Machine learning uses tools from a variety of mathematical fields.
+This document is an attempt to provide a summary of the mathematical background needed for an introductory class in machine learning, which at UC Berkeley is known as CS 189/289A.</p>
+</div>
+<div id="S1.p2" class="ltx_para ltx_noindent">
+<p id="S1.p2.1" class="ltx_p">Our assumption is that the reader is already familiar with the basic concepts of multivariable calculus and linear algebra (at the level of UCB Math 53/54).
+We emphasize that this document is <span id="S1.p2.1.1" class="ltx_text ltx_font_bold">not</span> a replacement for the prerequisite classes.
+Most subjects presented here are covered rather minimally; we intend to give an overview and point the interested reader to more comprehensive treatments for further details.</p>
+</div>
+<div id="S1.p3" class="ltx_para ltx_noindent">
+<p id="S1.p3.1" class="ltx_p">Note that this document concerns math background for machine learning, not machine learning itself.
+We will not discuss specific machine learning models or algorithms except possibly in passing to highlight the relevance of a mathematical concept.</p>
+</div>
+<div id="S1.p4" class="ltx_para ltx_noindent">
+<p id="S1.p4.1" class="ltx_p">Earlier versions of this document did not include proofs.
+We have begun adding in proofs where they are reasonably short and aid in understanding.
+These proofs are not necessary background for CS 189 but can be used to deepen the reader’s understanding.</p>
+</div>
+<div id="S1.p5" class="ltx_para ltx_noindent">
+<p id="S1.p5.1" class="ltx_p">You are free to distribute this document as you wish.
+The latest version can be found at <a href="http://gwthomas.github.io/docs/math4ml.pdf" title="" class="ltx_ref ltx_url ltx_font_typewriter">http://gwthomas.github.io/docs/math4ml.pdf</a>.
+Please report any mistakes to <a href="gwthomas@berkeley.edu" title="" class="ltx_ref ltx_url ltx_font_typewriter">gwthomas@berkeley.edu</a>.</p>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+<div class="ltx_TOC ltx_list_toc ltx_toc_toc">
+<h6>Contents</h6>
+<ul class="ltx_toclist">
+<li class="ltx_tocentry ltx_tocentry_section"><a href="#S1" title="1 About ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">1 </span>About</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_section"><a href="#S2" title="2 Notation ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">2 </span>Notation</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_section">
+<a href="#S3" title="3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3 </span>Linear Algebra</span></a>
+<ul class="ltx_toclist ltx_toclist_section">
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S3.SS1" title="3.1 Vector spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.1 </span>Vector spaces</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS1.SSS1" title="3.1.1 Euclidean space ‣ 3.1 Vector spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.1.1 </span>Euclidean space</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS1.SSS2" title="3.1.2 Subspaces ‣ 3.1 Vector spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.1.2 </span>Subspaces</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS2" title="3.2 Metric spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.2 </span>Metric spaces</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS3" title="3.3 Normed spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.3 </span>Normed spaces</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S3.SS4" title="3.4 Inner product spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.4 </span>Inner product spaces</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS4.SSS1" title="3.4.1 Pythagorean Theorem ‣ 3.4 Inner product spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.4.1 </span>Pythagorean Theorem</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS4.SSS2" title="3.4.2 Cauchy-Schwarz inequality ‣ 3.4 Inner product spaces ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.4.2 </span>Cauchy-Schwarz inequality</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS5" title="3.5 Transposition ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.5 </span>Transposition</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS6" title="3.6 Eigenthings ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.6 </span>Eigenthings</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS7" title="3.7 Trace ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.7 </span>Trace</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS8" title="3.8 Determinant ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.8 </span>Determinant</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS9" title="3.9 Orthogonal matrices ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.9 </span>Orthogonal matrices</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S3.SS10" title="3.10 Symmetric matrices ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.10 </span>Symmetric matrices</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS10.SSS1" title="3.10.1 Rayleigh quotients ‣ 3.10 Symmetric matrices ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.10.1 </span>Rayleigh quotients</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S3.SS11" title="3.11 Positive (semi-)definite matrices ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.11 </span>Positive (semi-)definite matrices</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS11.SSS1" title="3.11.1 The geometry of positive definite quadratic forms ‣ 3.11 Positive (semi-)definite matrices ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.11.1 </span>The geometry of positive definite quadratic forms</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S3.SS12" title="3.12 Singular value decomposition ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.12 </span>Singular value decomposition</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S3.SS13" title="3.13 Some useful matrix identities ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.13 </span>Some useful matrix identities</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS13.SSS1" title="3.13.1 Matrix-vector product as linear combination of matrix columns ‣ 3.13 Some useful matrix identities ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.13.1 </span>Matrix-vector product as linear combination of matrix columns</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS13.SSS2" title="3.13.2 Sum of outer products as matrix-matrix product ‣ 3.13 Some useful matrix identities ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.13.2 </span>Sum of outer products as matrix-matrix product</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S3.SS13.SSS3" title="3.13.3 Quadratic forms ‣ 3.13 Some useful matrix identities ‣ 3 Linear Algebra ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">3.13.3 </span>Quadratic forms</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_section">
+<a href="#S4" title="4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4 </span>Calculus and Optimization</span></a>
+<ul class="ltx_toclist ltx_toclist_section">
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS1" title="4.1 Extrema ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.1 </span>Extrema</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS2" title="4.2 Gradients ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.2 </span>Gradients</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS3" title="4.3 The Jacobian ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.3 </span>The Jacobian</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS4" title="4.4 The Hessian ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.4 </span>The Hessian</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S4.SS5" title="4.5 Matrix calculus ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.5 </span>Matrix calculus</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS5.SSS1" title="4.5.1 The chain rule ‣ 4.5 Matrix calculus ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.5.1 </span>The chain rule</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS6" title="4.6 Taylor’s theorem ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.6 </span>Taylor’s theorem</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS7" title="4.7 Conditions for local minima ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.7 </span>Conditions for local minima</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S4.SS8" title="4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8 </span>Convexity</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS8.SSS1" title="4.8.1 Convex sets ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8.1 </span>Convex sets</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS8.SSS2" title="4.8.2 Basics of convex functions ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8.2 </span>Basics of convex functions</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS8.SSS3" title="4.8.3 Consequences of convexity ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8.3 </span>Consequences of convexity</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS8.SSS4" title="4.8.4 Showing that a function is convex ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8.4 </span>Showing that a function is convex</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S4.SS8.SSS5" title="4.8.5 Examples ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.8.5 </span>Examples</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S4.SS9" title="4.9 Orthogonal projections ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">4.9 </span>Orthogonal projections</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_section">
+<a href="#S5" title="5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5 </span>Probability</span></a>
+<ul class="ltx_toclist ltx_toclist_section">
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS1" title="5.1 Basics ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.1 </span>Basics</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS1.SSS1" title="5.1.1 Conditional probability ‣ 5.1 Basics ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.1.1 </span>Conditional probability</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS1.SSS2" title="5.1.2 Chain rule ‣ 5.1 Basics ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.1.2 </span>Chain rule</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS1.SSS3" title="5.1.3 Bayes’ rule ‣ 5.1 Basics ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.1.3 </span>Bayes’ rule</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS2" title="5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.2 </span>Random variables</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS2.SSS1" title="5.2.1 The cumulative distribution function ‣ 5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.2.1 </span>The cumulative distribution function</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS2.SSS2" title="5.2.2 Discrete random variables ‣ 5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.2.2 </span>Discrete random variables</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS2.SSS3" title="5.2.3 Continuous random variables ‣ 5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.2.3 </span>Continuous random variables</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS2.SSS4" title="5.2.4 Other kinds of random variables ‣ 5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.2.4 </span>Other kinds of random variables</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS3" title="5.3 Joint distributions ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.3 </span>Joint distributions</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS3.SSS1" title="5.3.1 Independence of random variables ‣ 5.3 Joint distributions ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.3.1 </span>Independence of random variables</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS3.SSS2" title="5.3.2 Marginal distributions ‣ 5.3 Joint distributions ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.3.2 </span>Marginal distributions</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS4" title="5.4 Great Expectations ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.4 </span>Great Expectations</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS4.SSS1" title="5.4.1 Properties of expected value ‣ 5.4 Great Expectations ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.4.1 </span>Properties of expected value</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS5" title="5.5 Variance ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.5 </span>Variance</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS5.SSS1" title="5.5.1 Properties of variance ‣ 5.5 Variance ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.5.1 </span>Properties of variance</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS5.SSS2" title="5.5.2 Standard deviation ‣ 5.5 Variance ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.5.2 </span>Standard deviation</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS6" title="5.6 Covariance ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.6 </span>Covariance</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS6.SSS1" title="5.6.1 Correlation ‣ 5.6 Covariance ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.6.1 </span>Correlation</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection"><a href="#S5.SS7" title="5.7 Random vectors ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.7 </span>Random vectors</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS8" title="5.8 Estimation of Parameters ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.8 </span>Estimation of Parameters</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS8.SSS1" title="5.8.1 Maximum likelihood estimation ‣ 5.8 Estimation of Parameters ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.8.1 </span>Maximum likelihood estimation</span></a></li>
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS8.SSS2" title="5.8.2 Maximum a posteriori estimation ‣ 5.8 Estimation of Parameters ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.8.2 </span>Maximum a posteriori estimation</span></a></li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_subsection">
+<a href="#S5.SS9" title="5.9 The Gaussian distribution ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.9 </span>The Gaussian distribution</span></a>
+<ul class="ltx_toclist ltx_toclist_subsection">
+<li class="ltx_tocentry ltx_tocentry_subsubsection"><a href="#S5.SS9.SSS1" title="5.9.1 The geometry of multivariate Gaussians ‣ 5.9 The Gaussian distribution ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title"><span class="ltx_tag ltx_tag_ref">5.9.1 </span>The geometry of multivariate Gaussians</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="ltx_tocentry ltx_tocentry_bibliography"><a href="#bib" title="References ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_title">References</span></a></li>
+</ul>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+</section>
+<section id="S2" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">
+<span class="ltx_tag ltx_tag_section">2 </span>Notation</h2>
+
+<div id="S2.p1" class="ltx_para ltx_noindent">
+<table id="S2.p1.38" class="ltx_tabular ltx_guessed_headers ltx_align_middle">
+<thead class="ltx_thead">
+<tr id="S2.p1.38.39.1" class="ltx_tr">
+<th id="S2.p1.38.39.1.1" class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_th_row ltx_border_l ltx_border_r ltx_border_t">Notation</th>
+<th id="S2.p1.38.39.1.2" class="ltx_td ltx_align_left ltx_th ltx_th_column ltx_border_r ltx_border_t">Meaning</th>
+</tr>
+</thead>
+<tbody class="ltx_tbody">
+<tr id="S2.p1.1.1" class="ltx_tr">
+<th id="S2.p1.1.1.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r ltx_border_t"><math id="S2.p1.1.1.1.m1" class="ltx_Math" alttext="\mathbb{R}" display="inline"><mi>ℝ</mi></math></th>
+<td id="S2.p1.1.1.2" class="ltx_td ltx_align_left ltx_border_r ltx_border_t">set of real numbers</td>
+</tr>
+<tr id="S2.p1.3.3" class="ltx_tr">
+<th id="S2.p1.2.2.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.2.2.1.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math></th>
+<td id="S2.p1.3.3.2" class="ltx_td ltx_align_left ltx_border_r">set (vector space) of <math id="S2.p1.3.3.2.m1" class="ltx_Math" alttext="n" display="inline"><mi>n</mi></math>-tuples of real numbers, endowed with the usual inner product</td>
+</tr>
+<tr id="S2.p1.6.6" class="ltx_tr">
+<th id="S2.p1.4.4.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.4.4.1.m1" class="ltx_Math" alttext="\mathbb{R}^{m\times n}" display="inline"><msup><mi>ℝ</mi><mrow><mi>m</mi><mo>×</mo><mi>n</mi></mrow></msup></math></th>
+<td id="S2.p1.6.6.3" class="ltx_td ltx_align_left ltx_border_r">set (vector space) of <math id="S2.p1.5.5.2.m1" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math>-by-<math id="S2.p1.6.6.3.m2" class="ltx_Math" alttext="n" display="inline"><mi>n</mi></math> matrices</td>
+</tr>
+<tr id="S2.p1.10.10" class="ltx_tr">
+<th id="S2.p1.7.7.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.7.7.1.m1" class="ltx_Math" alttext="\delta_{ij}" display="inline"><msub><mi>δ</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub></math></th>
+<td id="S2.p1.10.10.4" class="ltx_td ltx_align_left ltx_border_r">Kronecker delta, i.e. <math id="S2.p1.8.8.2.m1" class="ltx_Math" alttext="\delta_{ij}=1" display="inline"><mrow><msub><mi>δ</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mn>1</mn></mrow></math> if <math id="S2.p1.9.9.3.m2" class="ltx_Math" alttext="i=j" display="inline"><mrow><mi>i</mi><mo>=</mo><mi>j</mi></mrow></math>, <math id="S2.p1.10.10.4.m3" class="ltx_Math" alttext="0" display="inline"><mn>0</mn></math> otherwise</td>
+</tr>
+<tr id="S2.p1.13.13" class="ltx_tr">
+<th id="S2.p1.11.11.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.11.11.1.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x})" display="inline"><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.13.13.3" class="ltx_td ltx_align_left ltx_border_r">gradient of the function <math id="S2.p1.12.12.2.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> at <math id="S2.p1.13.13.3.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.16.16" class="ltx_tr">
+<th id="S2.p1.14.14.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.14.14.1.m1" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.16.16.3" class="ltx_td ltx_align_left ltx_border_r">Hessian of the function <math id="S2.p1.15.15.2.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> at <math id="S2.p1.16.16.3.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.18.18" class="ltx_tr">
+<th id="S2.p1.17.17.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.17.17.1.m1" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math></th>
+<td id="S2.p1.18.18.2" class="ltx_td ltx_align_left ltx_border_r">transpose of the matrix <math id="S2.p1.18.18.2.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.19.19" class="ltx_tr">
+<th id="S2.p1.19.19.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.19.19.1.m1" class="ltx_Math" alttext="\Omega" display="inline"><mi mathvariant="normal">Ω</mi></math></th>
+<td id="S2.p1.19.19.2" class="ltx_td ltx_align_left ltx_border_r">sample space</td>
+</tr>
+<tr id="S2.p1.21.21" class="ltx_tr">
+<th id="S2.p1.20.20.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.20.20.1.m1" class="ltx_Math" alttext="\mathbb{P}(A)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.21.21.2" class="ltx_td ltx_align_left ltx_border_r">probability of event <math id="S2.p1.21.21.2.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.23.23" class="ltx_tr">
+<th id="S2.p1.22.22.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.22.22.1.m1" class="ltx_Math" alttext="p(X)" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.23.23.2" class="ltx_td ltx_align_left ltx_border_r">distribution of random variable <math id="S2.p1.23.23.2.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.25.25" class="ltx_tr">
+<th id="S2.p1.24.24.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.24.24.1.m1" class="ltx_Math" alttext="p(x)" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.25.25.2" class="ltx_td ltx_align_left ltx_border_r">probability density/mass function evaluated at <math id="S2.p1.25.25.2.m1" class="ltx_Math" alttext="x" display="inline"><mi>x</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.27.27" class="ltx_tr">
+<th id="S2.p1.26.26.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.26.26.1.m1" class="ltx_Math" alttext="A^{\text{c}}" display="inline"><msup><mi>A</mi><mtext>c</mtext></msup></math></th>
+<td id="S2.p1.27.27.2" class="ltx_td ltx_align_left ltx_border_r">complement of event <math id="S2.p1.27.27.2.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.31.31" class="ltx_tr">
+<th id="S2.p1.28.28.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.28.28.1.m1" class="ltx_Math" alttext="A\mathbin{\dot{\cup}}B" display="inline"><mrow><mi>A</mi><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><mi>B</mi></mrow></math></th>
+<td id="S2.p1.31.31.4" class="ltx_td ltx_align_left ltx_border_r">union of <math id="S2.p1.29.29.2.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> and <math id="S2.p1.30.30.3.m2" class="ltx_Math" alttext="B" display="inline"><mi>B</mi></math>, with the extra requirement that <math id="S2.p1.31.31.4.m3" class="ltx_Math" alttext="A\cap B=\varnothing" display="inline"><mrow><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo>=</mo><mi mathvariant="normal">∅</mi></mrow></math>
+</td>
+</tr>
+<tr id="S2.p1.33.33" class="ltx_tr">
+<th id="S2.p1.32.32.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.32.32.1.m1" class="ltx_Math" alttext="\mathbb{E}[X]" display="inline"><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow></math></th>
+<td id="S2.p1.33.33.2" class="ltx_td ltx_align_left ltx_border_r">expected value of random variable <math id="S2.p1.33.33.2.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.35.35" class="ltx_tr">
+<th id="S2.p1.34.34.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_l ltx_border_r"><math id="S2.p1.34.34.1.m1" class="ltx_Math" alttext="\operatorname{Var}(X)" display="inline"><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.35.35.2" class="ltx_td ltx_align_left ltx_border_r">variance of random variable <math id="S2.p1.35.35.2.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>
+</td>
+</tr>
+<tr id="S2.p1.38.38" class="ltx_tr">
+<th id="S2.p1.36.36.1" class="ltx_td ltx_align_left ltx_th ltx_th_row ltx_border_b ltx_border_l ltx_border_r"><math id="S2.p1.36.36.1.m1" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)" display="inline"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></math></th>
+<td id="S2.p1.38.38.3" class="ltx_td ltx_align_left ltx_border_b ltx_border_r">covariance of random variables <math id="S2.p1.37.37.2.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and <math id="S2.p1.38.38.3.m2" class="ltx_Math" alttext="Y" display="inline"><mi>Y</mi></math>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div id="S2.p2" class="ltx_para ltx_noindent">
+<p id="S2.p2.1" class="ltx_p">Other notes:</p>
+<ul id="S2.I1" class="ltx_itemize">
+<li id="S2.I1.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">•</span> 
+<div id="S2.I1.i1.p1" class="ltx_para ltx_noindent">
+<p id="S2.I1.i1.p1.2" class="ltx_p">Vectors and matrices are in bold (e.g. <math id="S2.I1.i1.p1.1.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{A}" display="inline"><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐀</mi></mrow></math>).
+This is true for vectors in <math id="S2.I1.i1.p1.2.m2" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> as well as for vectors in general vector spaces.
+We generally use Greek letters for scalars and capital Roman letters for matrices and random variables.</p>
+</div>
+</li>
+<li id="S2.I1.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">•</span> 
+<div id="S2.I1.i2.p1" class="ltx_para ltx_noindent">
+<p id="S2.I1.i2.p1.1" class="ltx_p">To stay focused at an appropriate level of abstraction, we restrict ourselves to real values.
+In many places in this document, it is entirely possible to generalize to the complex case, but we will simply state the version that applies to the reals.</p>
+</div>
+</li>
+<li id="S2.I1.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">•</span> 
+<div id="S2.I1.i3.p1" class="ltx_para ltx_noindent">
+<p id="S2.I1.i3.p1.5" class="ltx_p">We assume that vectors are column vectors, i.e. that a vector in <math id="S2.I1.i3.p1.1.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> can be interpreted as an <math id="S2.I1.i3.p1.2.m2" class="ltx_Math" alttext="n" display="inline"><mi>n</mi></math>-by-<math id="S2.I1.i3.p1.3.m3" class="ltx_Math" alttext="1" display="inline"><mn>1</mn></math> matrix.
+As such, taking the transpose of a vector is well-defined (and produces a row vector, which is a <math id="S2.I1.i3.p1.4.m4" class="ltx_Math" alttext="1" display="inline"><mn>1</mn></math>-by-<math id="S2.I1.i3.p1.5.m5" class="ltx_Math" alttext="n" display="inline"><mi>n</mi></math> matrix).</p>
+</div>
+</li>
+</ul>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+</section>
+<section id="S3" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">
+<span class="ltx_tag ltx_tag_section">3 </span>Linear Algebra</h2>
+
+<div id="S3.p1" class="ltx_para ltx_noindent">
+<p id="S3.p1.1" class="ltx_p">In this section we present important classes of spaces in which our data will live and our operations will take place: vector spaces, metric spaces, normed spaces, and inner product spaces.
+Generally speaking, these are defined in such a way as to capture one or more important properties of Euclidean space but in a more general way.</p>
+</div>
+<section id="S3.SS1" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.1 </span>Vector spaces</h3>
+
+<div id="S3.SS1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS1.p1.2" class="ltx_p"><span id="S3.SS1.p1.2.1" class="ltx_text ltx_font_bold">Vector spaces</span> are the basic setting in which linear algebra happens.
+A vector space <math id="S3.SS1.p1.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> is a set (the elements of which are called <span id="S3.SS1.p1.2.2" class="ltx_text ltx_font_bold">vectors</span>) on which two operations are defined: vectors can be added together, and vectors can be multiplied by real numbers<span id="footnote1" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">1</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">1</sup><span class="ltx_tag ltx_tag_note">1</span>
+More generally, vector spaces can be defined over any <span id="footnote1.1" class="ltx_text ltx_font_bold">field</span> <math id="footnote1.m1" class="ltx_Math" alttext="\mathbb{F}" display="inline"><mi>𝔽</mi></math>.
+We take <math id="footnote1.m2" class="ltx_Math" alttext="\mathbb{F}=\mathbb{R}" display="inline"><mrow><mi>𝔽</mi><mo>=</mo><mi>ℝ</mi></mrow></math> in this document to avoid an unnecessary diversion into abstract algebra.
+</span></span></span> called <span id="S3.SS1.p1.2.3" class="ltx_text ltx_font_bold">scalars</span>.
+<math id="S3.SS1.p1.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> must satisfy</p>
+<ol id="S3.I1" class="ltx_enumerate">
+<li id="S3.I1.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I1.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i1.p1.4" class="ltx_p">There exists an additive identity (written <math id="S3.I1.i1.p1.1.m1" class="ltx_Math" alttext="\mathbf{0}" display="inline"><mn>𝟎</mn></math>) in <math id="S3.I1.i1.p1.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> such that <math id="S3.I1.i1.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}+\mathbf{0}=\mathbf{x}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>+</mo><mn>𝟎</mn></mrow><mo>=</mo><mi>𝐱</mi></mrow></math> for all <math id="S3.I1.i1.p1.4.m4" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I1.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I1.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i2.p1.3" class="ltx_p">For each <math id="S3.I1.i2.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>, there exists an additive inverse (written <math id="S3.I1.i2.p1.2.m2" class="ltx_Math" alttext="\mathbf{-x}" display="inline"><mrow><mo>-</mo><mi>𝐱</mi></mrow></math>) such that <math id="S3.I1.i2.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}+(\mathbf{-x})=\mathbf{0}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>+</mo><mrow><mo stretchy="false">(</mo><mrow><mo>-</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>𝟎</mn></mrow></math></p>
+</div>
+</li>
+<li id="S3.I1.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I1.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i3.p1.4" class="ltx_p">There exists a multiplicative identity (written <math id="S3.I1.i3.p1.1.m1" class="ltx_Math" alttext="1" display="inline"><mn>1</mn></math>) in <math id="S3.I1.i3.p1.2.m2" class="ltx_Math" alttext="\mathbb{R}" display="inline"><mi>ℝ</mi></math> such that <math id="S3.I1.i3.p1.3.m3" class="ltx_Math" alttext="1\mathbf{x}=\mathbf{x}" display="inline"><mrow><mrow><mn>1</mn><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mi>𝐱</mi></mrow></math> for all <math id="S3.I1.i3.p1.4.m4" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I1.i4" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iv)</span> 
+<div id="S3.I1.i4.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i4.p1.2" class="ltx_p">Commutativity: <math id="S3.I1.i4.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}+\mathbf{y}=\mathbf{y}+\mathbf{x}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>=</mo><mrow><mi>𝐲</mi><mo>+</mo><mi>𝐱</mi></mrow></mrow></math> for all <math id="S3.I1.i4.p1.2.m2" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I1.i5" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(v)</span> 
+<div id="S3.I1.i5.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i5.p1.4" class="ltx_p">Associativity: <math id="S3.I1.i5.p1.1.m1" class="ltx_Math" alttext="(\mathbf{x}+\mathbf{y})+\mathbf{z}=\mathbf{x}+(\mathbf{y}+\mathbf{z})" display="inline"><mrow><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo stretchy="false">)</mo></mrow><mo>+</mo><mi>𝐳</mi></mrow><mo>=</mo><mrow><mi>𝐱</mi><mo>+</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐲</mi><mo>+</mo><mi>𝐳</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math> and <math id="S3.I1.i5.p1.2.m2" class="ltx_Math" alttext="\alpha(\beta\mathbf{x})=(\alpha\beta)\mathbf{x}" display="inline"><mrow><mrow><mi>α</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>β</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>β</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math> for all <math id="S3.I1.i5.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y},\mathbf{z}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo>,</mo><mi>𝐳</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math> and <math id="S3.I1.i5.p1.4.m4" class="ltx_Math" alttext="\alpha,\beta\in\mathbb{R}" display="inline"><mrow><mrow><mi>α</mi><mo>,</mo><mi>β</mi></mrow><mo>∈</mo><mi>ℝ</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I1.i6" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(vi)</span> 
+<div id="S3.I1.i6.p1" class="ltx_para ltx_noindent">
+<p id="S3.I1.i6.p1.4" class="ltx_p">Distributivity: <math id="S3.I1.i6.p1.1.m1" class="ltx_Math" alttext="\alpha(\mathbf{x}+\mathbf{y})=\alpha\mathbf{x}+\alpha\mathbf{y}" display="inline"><mrow><mrow><mi>α</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐲</mi></mrow></mrow></mrow></math> and <math id="S3.I1.i6.p1.2.m2" class="ltx_Math" alttext="(\alpha+\beta)\mathbf{x}=\alpha\mathbf{x}+\beta\mathbf{x}" display="inline"><mrow><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>+</mo><mi>β</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></mrow></math> for all <math id="S3.I1.i6.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math> and <math id="S3.I1.i6.p1.4.m4" class="ltx_Math" alttext="\alpha,\beta\in\mathbb{R}" display="inline"><mrow><mrow><mi>α</mi><mo>,</mo><mi>β</mi></mrow><mo>∈</mo><mi>ℝ</mi></mrow></math></p>
+</div>
+</li>
+</ol>
+</div>
+<section id="S3.SS1.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.1.1 </span>Euclidean space</h4>
+
+<div id="S3.SS1.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS1.SSS1.p1.2" class="ltx_p">The quintessential vector space is <span id="S3.SS1.SSS1.p1.2.1" class="ltx_text ltx_font_bold">Euclidean space</span>, which we denote <math id="S3.SS1.SSS1.p1.1.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math>.
+The vectors in this space consist of <math id="S3.SS1.SSS1.p1.2.m2" class="ltx_Math" alttext="n" display="inline"><mi>n</mi></math>-tuples of real numbers:</p>
+<table id="S3.Ex1" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex1.m1" class="ltx_Math" alttext="\mathbf{x}=(x_{1},x_{2},\dots,x_{n})" display="block"><mrow><mi>𝐱</mi><mo>=</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><msub><mi>x</mi><mn>2</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>x</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS1.SSS1.p1.3" class="ltx_p">For our purposes, it will be useful to think of them as <math id="S3.SS1.SSS1.p1.3.m1" class="ltx_Math" alttext="n\times 1" display="inline"><mrow><mi>n</mi><mo>×</mo><mn>1</mn></mrow></math> matrices, or <span id="S3.SS1.SSS1.p1.3.1" class="ltx_text ltx_font_bold">column vectors</span>:
+</p>
+<table id="S3.Ex2" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex2.m1" class="ltx_Math" alttext="\mathbf{x}=\begin{bmatrix}x_{1}\\
+x_{2}\\
+\vdots\\
+x_{n}\end{bmatrix}" display="block"><mrow><mi>𝐱</mi><mo>=</mo><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><msub><mi>x</mi><mn>1</mn></msub></mtd></mtr><mtr><mtd columnalign="center"><msub><mi>x</mi><mn>2</mn></msub></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><msub><mi>x</mi><mi>n</mi></msub></mtd></mtr></mtable><mo>]</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS1.SSS1.p1.4" class="ltx_p">Addition and scalar multiplication are defined component-wise on vectors in <math id="S3.SS1.SSS1.p1.4.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math>:</p>
+<table id="S3.Ex3" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex3.m1" class="ltx_Math" alttext="\mathbf{x}+\mathbf{y}=\begin{bmatrix}x_{1}+y_{1}\\
+\vdots\\
+x_{n}+y_{n}\end{bmatrix},\hskip 14.22636pt\alpha\mathbf{x}=\begin{bmatrix}%
+\alpha x_{1}\\
+\vdots\\
+\alpha x_{n}\end{bmatrix}" display="block"><mrow><mrow><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>=</mo><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mrow><msub><mi>x</mi><mn>1</mn></msub><mo>+</mo><msub><mi>y</mi><mn>1</mn></msub></mrow></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mrow><msub><mi>x</mi><mi>n</mi></msub><mo>+</mo><msub><mi>y</mi><mi>n</mi></msub></mrow></mtd></mtr></mtable><mo>]</mo></mrow></mrow><mo rspace="16.7pt">,</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mrow><mi>α</mi><mo>⁢</mo><msub><mi>x</mi><mn>1</mn></msub></mrow></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mrow><mi>α</mi><mo>⁢</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></mtd></mtr></mtable><mo>]</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS1.SSS1.p1.6" class="ltx_p">Euclidean space is used to mathematically represent physical space, with notions such as distance, length, and angles.
+Although it becomes hard to visualize for <math id="S3.SS1.SSS1.p1.5.m1" class="ltx_Math" alttext="n&gt;3" display="inline"><mrow><mi>n</mi><mo>&gt;</mo><mn>3</mn></mrow></math>, these concepts generalize mathematically in obvious ways.
+Even when you’re working in more general settings than <math id="S3.SS1.SSS1.p1.6.m2" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math>, it is often useful to visualize vector addition and scalar multiplication in terms of 2D vectors in the plane or 3D vectors in space.</p>
+</div>
+</section>
+<section id="S3.SS1.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.1.2 </span>Subspaces</h4>
+
+<div id="S3.SS1.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS1.SSS2.p1.3" class="ltx_p">Vector spaces can contain other vector spaces.
+If <math id="S3.SS1.SSS2.p1.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> is a vector space, then <math id="S3.SS1.SSS2.p1.2.m2" class="ltx_Math" alttext="S\subseteq V" display="inline"><mrow><mi>S</mi><mo>⊆</mo><mi>V</mi></mrow></math> is said to be a <span id="S3.SS1.SSS2.p1.3.1" class="ltx_text ltx_font_bold">subspace</span> of <math id="S3.SS1.SSS2.p1.3.m3" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> if</p>
+<ol id="S3.I2" class="ltx_enumerate">
+<li id="S3.I2.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I2.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I2.i1.p1.1" class="ltx_p"><math id="S3.I2.i1.p1.1.m1" class="ltx_Math" alttext="\mathbf{0}\in S" display="inline"><mrow><mn>𝟎</mn><mo>∈</mo><mi>S</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I2.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I2.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I2.i2.p1.3" class="ltx_p"><math id="S3.I2.i2.p1.1.m1" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> is closed under addition: <math id="S3.I2.i2.p1.2.m2" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math> implies <math id="S3.I2.i2.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}+\mathbf{y}\in S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I2.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I2.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I2.i3.p1.3" class="ltx_p"><math id="S3.I2.i3.p1.1.m1" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> is closed under scalar multiplication: <math id="S3.I2.i3.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}\in S,\alpha\in\mathbb{R}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>∈</mo><mi>S</mi></mrow><mo>,</mo><mrow><mi>α</mi><mo>∈</mo><mi>ℝ</mi></mrow></mrow></math> implies <math id="S3.I2.i3.p1.3.m3" class="ltx_Math" alttext="\alpha\mathbf{x}\in S" display="inline"><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math></p>
+</div>
+</li>
+</ol>
+<p id="S3.SS1.SSS2.p1.6" class="ltx_p">Note that <math id="S3.SS1.SSS2.p1.4.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> is always a subspace of <math id="S3.SS1.SSS2.p1.5.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>, as is the trivial vector space which contains only <math id="S3.SS1.SSS2.p1.6.m3" class="ltx_Math" alttext="\mathbf{0}" display="inline"><mn>𝟎</mn></math>.</p>
+</div>
+<div id="S3.SS1.SSS2.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS1.SSS2.p2.1" class="ltx_p">As a concrete example, a line passing through the origin is a subspace of Euclidean space.</p>
+</div>
+<div id="S3.SS1.SSS2.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS1.SSS2.p3.2" class="ltx_p">Some of the most important subspaces are those induced by linear maps.
+If <math id="S3.SS1.SSS2.p3.1.m1" class="ltx_Math" alttext="T\mathrel{\mathop{:}}V\to W" display="inline"><mrow><mi>T</mi><mo>:</mo><mi>V</mi><mo>→</mo><mi>W</mi></mrow></math> is a linear map, we define the <span id="S3.SS1.SSS2.p3.2.1" class="ltx_text ltx_font_bold">nullspace<span id="footnote2" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">2</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">2</sup><span class="ltx_tag ltx_tag_note"><span id="footnote2.1.1.1" class="ltx_text ltx_font_medium">2</span></span><span id="footnote2.5" class="ltx_text ltx_font_medium">
+It is sometimes called the </span><span id="footnote2.6" class="ltx_text">kernel</span><span id="footnote2.7" class="ltx_text ltx_font_medium"> by algebraists, but we eschew this terminology because the word “kernel” has another meaning in machine learning.
+</span></span></span></span></span> of <math id="S3.SS1.SSS2.p3.2.m2" class="ltx_Math" alttext="T" display="inline"><mi>T</mi></math> as</p>
+<table id="S3.Ex4" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex4.m1" class="ltx_Math" alttext="\operatorname*{null}(T)=\{\mathbf{x}\in V\mid T\mathbf{x}=\mathbf{0}\}" display="block"><mrow><mrow><mo movablelimits="false">null</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>T</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow><mo>∣</mo><mrow><mrow><mi>T</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mn>𝟎</mn></mrow><mo stretchy="false">}</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS1.SSS2.p3.3" class="ltx_p">and the <span id="S3.SS1.SSS2.p3.3.1" class="ltx_text ltx_font_bold">range</span> (or the <span id="S3.SS1.SSS2.p3.3.2" class="ltx_text ltx_font_bold">columnspace</span> if we are considering the matrix form) of <math id="S3.SS1.SSS2.p3.3.m1" class="ltx_Math" alttext="T" display="inline"><mi>T</mi></math> as
+</p>
+<table id="S3.Ex5" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex5.m1" class="ltx_Math" alttext="\operatorname*{range}(T)=\{\mathbf{y}\in W\mid\text{$\exists\mathbf{x}\in V$ %
+such that $T\mathbf{x}=\mathbf{y}$}\}" display="block"><mrow><mrow><mo movablelimits="false">range</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>T</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>𝐲</mi><mo>∈</mo><mi>W</mi></mrow><mo>∣</mo><mrow><mrow><mrow><mo>∃</mo><mi>𝐱</mi></mrow><mo>∈</mo><mi>V</mi></mrow><mtext> such that </mtext><mrow><mrow><mi>T</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS1.SSS2.p3.4" class="ltx_p">It is a good exercise to verify that the nullspace and range of a linear map are always subspaces of its domain and codomain, respectively.</p>
+</div>
+</section>
+</section>
+<section id="S3.SS2" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.2 </span>Metric spaces</h3>
+
+<div id="S3.SS2.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS2.p1.1" class="ltx_p">Metrics generalize the notion of distance from Euclidean space (although metric spaces need not be vector spaces).</p>
+</div>
+<div id="S3.SS2.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS2.p2.2" class="ltx_p">A <span id="S3.SS2.p2.2.1" class="ltx_text ltx_font_bold">metric</span> on a set <math id="S3.SS2.p2.1.m1" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> is a function <math id="S3.SS2.p2.2.m2" class="ltx_Math" alttext="d\mathrel{\mathop{:}}S\times S\to\mathbb{R}" display="inline"><mrow><mi>d</mi><mo>:</mo><mrow><mi>S</mi><mo>×</mo><mi>S</mi></mrow><mo>→</mo><mi>ℝ</mi></mrow></math> that satisfies</p>
+<ol id="S3.I3" class="ltx_enumerate">
+<li id="S3.I3.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I3.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I3.i1.p1.2" class="ltx_p"><math id="S3.I3.i1.p1.1.m1" class="ltx_Math" alttext="d(x,y)\geq 0" display="inline"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≥</mo><mn>0</mn></mrow></math>, with equality if and only if <math id="S3.I3.i1.p1.2.m2" class="ltx_Math" alttext="x=y" display="inline"><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I3.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I3.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I3.i2.p1.1" class="ltx_p"><math id="S3.I3.i2.p1.1.m1" class="ltx_Math" alttext="d(x,y)=d(y,x)" display="inline"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>y</mi><mo>,</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I3.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I3.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I3.i3.p1.1" class="ltx_p"><math id="S3.I3.i3.p1.1.m1" class="ltx_Math" alttext="d(x,z)\leq d(x,y)+d(y,z)" display="inline"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>z</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>y</mi><mo>,</mo><mi>z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math> (the so-called <span id="S3.I3.i3.p1.1.1" class="ltx_text ltx_font_bold">triangle inequality</span>)</p>
+</div>
+</li>
+</ol>
+<p id="S3.SS2.p2.3" class="ltx_p">for all <math id="S3.SS2.p2.3.m1" class="ltx_Math" alttext="x,y,z\in S" display="inline"><mrow><mrow><mi>x</mi><mo>,</mo><mi>y</mi><mo>,</mo><mi>z</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math>.</p>
+</div>
+<div id="S3.SS2.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS2.p3.7" class="ltx_p">A key motivation for metrics is that they allow limits to be defined for mathematical objects other than real numbers.
+We say that a sequence <math id="S3.SS2.p3.1.m1" class="ltx_Math" alttext="\{x_{n}\}\subseteq S" display="inline"><mrow><mrow><mo stretchy="false">{</mo><msub><mi>x</mi><mi>n</mi></msub><mo stretchy="false">}</mo></mrow><mo>⊆</mo><mi>S</mi></mrow></math> converges to the limit <math id="S3.SS2.p3.2.m2" class="ltx_Math" alttext="x" display="inline"><mi>x</mi></math> if for any <math id="S3.SS2.p3.3.m3" class="ltx_Math" alttext="\epsilon&gt;0" display="inline"><mrow><mi>ϵ</mi><mo>&gt;</mo><mn>0</mn></mrow></math>, there exists <math id="S3.SS2.p3.4.m4" class="ltx_Math" alttext="N\in\mathbb{N}" display="inline"><mrow><mi>N</mi><mo>∈</mo><mi>ℕ</mi></mrow></math> such that <math id="S3.SS2.p3.5.m5" class="ltx_Math" alttext="d(x_{n},x)&lt;\epsilon" display="inline"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mi>n</mi></msub><mo>,</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mi>ϵ</mi></mrow></math> for all <math id="S3.SS2.p3.6.m6" class="ltx_Math" alttext="n\geq N" display="inline"><mrow><mi>n</mi><mo>≥</mo><mi>N</mi></mrow></math>.
+Note that the definition for limits of sequences of real numbers, which you have likely seen in a calculus class, is a special case of this definition when using the metric <math id="S3.SS2.p3.7.m7" class="ltx_Math" alttext="d(x,y)=|x-y|" display="inline"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo stretchy="false">|</mo><mrow><mi>x</mi><mo>-</mo><mi>y</mi></mrow><mo stretchy="false">|</mo></mrow></mrow></math>.</p>
+</div>
+</section>
+<section id="S3.SS3" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.3 </span>Normed spaces</h3>
+
+<div id="S3.SS3.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS3.p1.1" class="ltx_p">Norms generalize the notion of length from Euclidean space.</p>
+</div>
+<div id="S3.SS3.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS3.p2.2" class="ltx_p">A <span id="S3.SS3.p2.2.1" class="ltx_text ltx_font_bold">norm</span> on a real vector space <math id="S3.SS3.p2.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> is a function <math id="S3.SS3.p2.2.m2" class="ltx_Math" alttext="\|\cdot\|\mathrel{\mathop{:}}V\to\mathbb{R}" display="inline"><mrow><mo>∥</mo><mo>⋅</mo><mo>∥</mo><mo>:</mo><mi>V</mi><mo>→</mo><mi>ℝ</mi></mrow></math> that satisfies</p>
+<ol id="S3.I4" class="ltx_enumerate">
+<li id="S3.I4.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I4.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I4.i1.p1.2" class="ltx_p"><math id="S3.I4.i1.p1.1.m1" class="ltx_Math" alttext="\|\mathbf{x}\|\geq 0" display="inline"><mrow><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mo>≥</mo><mn>0</mn></mrow></math>, with equality if and only if <math id="S3.I4.i1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math></p>
+</div>
+</li>
+<li id="S3.I4.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I4.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I4.i2.p1.1" class="ltx_p"><math id="S3.I4.i2.p1.1.m1" class="ltx_Math" alttext="\|\alpha\mathbf{x}\|=|\alpha|\|\mathbf{x}\|" display="inline"><mrow><mrow><mo>∥</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>∥</mo></mrow><mo>=</mo><mrow><mrow><mo stretchy="false">|</mo><mi>α</mi><mo stretchy="false">|</mo></mrow><mo>⁢</mo><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow></mrow></mrow></math>
+</p>
+</div>
+</li>
+<li id="S3.I4.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I4.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I4.i3.p1.1" class="ltx_p"><math id="S3.I4.i3.p1.1.m1" class="ltx_Math" alttext="\|\mathbf{x}+\mathbf{y}\|\leq\|\mathbf{x}\|+\|\mathbf{y}\|" display="inline"><mrow><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mo>≤</mo><mrow><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mo>+</mo><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow></mrow></mrow></math> (the <span id="S3.I4.i3.p1.1.1" class="ltx_text ltx_font_bold">triangle inequality</span> again)</p>
+</div>
+</li>
+</ol>
+<p id="S3.SS3.p2.4" class="ltx_p">for all <math id="S3.SS3.p2.3.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math> and all <math id="S3.SS3.p2.4.m2" class="ltx_Math" alttext="\alpha\in\mathbb{R}" display="inline"><mrow><mi>α</mi><mo>∈</mo><mi>ℝ</mi></mrow></math>.
+A vector space endowed with a norm is called a <span id="S3.SS3.p2.4.1" class="ltx_text ltx_font_bold">normed vector space</span>, or simply a <span id="S3.SS3.p2.4.2" class="ltx_text ltx_font_bold">normed space</span>.</p>
+</div>
+<div id="S3.SS3.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS3.p3.2" class="ltx_p">Note that any norm on <math id="S3.SS3.p3.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> induces a distance metric on <math id="S3.SS3.p3.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>:</p>
+<table id="S3.Ex6" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex6.m1" class="ltx_Math" alttext="d(\mathbf{x},\mathbf{y})=\|\mathbf{x}-\mathbf{y}\|" display="block"><mrow><mrow><mi>d</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS3.p3.3" class="ltx_p">One can verify that the axioms for metrics are satisfied under this definition and follow directly from the axioms for norms.
+Therefore any normed space is also a metric space.<span id="footnote3" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">3</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">3</sup><span class="ltx_tag ltx_tag_note">3</span>
+If a normed space is complete with respect to the distance metric induced by its norm, we say that it is a <span id="footnote3.1" class="ltx_text ltx_font_bold">Banach space</span>.
+</span></span></span></p>
+</div>
+<div id="S3.SS3.p4" class="ltx_para ltx_noindent">
+<p id="S3.SS3.p4.1" class="ltx_p">We will typically only be concerned with a few specific norms on <math id="S3.SS3.p4.1.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math>:</p>
+<table id="Sx1.EGx1" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S3.Ex7"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex7.m1" class="ltx_Math" alttext="\displaystyle\|\mathbf{x}\|_{1}" display="inline"><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>1</mn></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex7.m2" class="ltx_Math" alttext="\displaystyle=\sum_{i=1}^{n}|x_{i}|" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mstyle displaystyle="true"><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover></mstyle><mrow><mo stretchy="false">|</mo><msub><mi>x</mi><mi>i</mi></msub><mo stretchy="false">|</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S3.Ex8"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex8.m1" class="ltx_Math" alttext="\displaystyle\|\mathbf{x}\|_{2}" display="inline"><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex8.m2" class="ltx_Math" alttext="\displaystyle=\sqrt{\sum_{i=1}^{n}x_{i}^{2}}" display="inline"><mrow><mi></mi><mo>=</mo><msqrt><mrow><mstyle displaystyle="true"><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover></mstyle><msubsup><mi>x</mi><mi>i</mi><mn>2</mn></msubsup></mrow></msqrt></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S3.Ex9"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex9.m1" class="ltx_Math" alttext="\displaystyle\|\mathbf{x}\|_{p}" display="inline"><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mi>p</mi></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex9.m2" class="ltx_Math" alttext="\displaystyle=\left(\sum_{i=1}^{n}|x_{i}|^{p}\right)^{\frac{1}{p}}\hskip 14.22%
+636pt\hskip 14.22636pt(p\geq 1)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><msup><mrow><mo>(</mo><mrow><mstyle displaystyle="true"><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover></mstyle><msup><mrow><mo stretchy="false">|</mo><msub><mi>x</mi><mi>i</mi></msub><mo stretchy="false">|</mo></mrow><mi>p</mi></msup></mrow><mo>)</mo></mrow><mfrac><mn>1</mn><mi>p</mi></mfrac></msup><mo mathvariant="italic" separator="true">    </mo><mrow><mo stretchy="false">(</mo><mrow><mi>p</mi><mo>≥</mo><mn>1</mn></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S3.Ex10"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex10.m1" class="ltx_Math" alttext="\displaystyle\|\mathbf{x}\|_{\infty}" display="inline"><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mi mathvariant="normal">∞</mi></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex10.m2" class="ltx_Math" alttext="\displaystyle=\max_{1\leq i\leq n}|x_{i}|" display="inline"><mrow><mi></mi><mo>=</mo><mrow><munder><mi>max</mi><mrow><mn>1</mn><mo>≤</mo><mi>i</mi><mo>≤</mo><mi>n</mi></mrow></munder><mo>⁡</mo><mrow><mo stretchy="false">|</mo><msub><mi>x</mi><mi>i</mi></msub><mo stretchy="false">|</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S3.SS3.p4.8" class="ltx_p">Note that the 1- and 2-norms are special cases of the <math id="S3.SS3.p4.2.m1" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math>-norm, and the <math id="S3.SS3.p4.3.m2" class="ltx_Math" alttext="\infty" display="inline"><mi mathvariant="normal">∞</mi></math>-norm is the limit of the <math id="S3.SS3.p4.4.m3" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math>-norm as <math id="S3.SS3.p4.5.m4" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math> tends to infinity.
+We require <math id="S3.SS3.p4.6.m5" class="ltx_Math" alttext="p\geq 1" display="inline"><mrow><mi>p</mi><mo>≥</mo><mn>1</mn></mrow></math> for the general definition of the <math id="S3.SS3.p4.7.m6" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math>-norm because the triangle inequality fails to hold if <math id="S3.SS3.p4.8.m7" class="ltx_Math" alttext="p&lt;1" display="inline"><mrow><mi>p</mi><mo>&lt;</mo><mn>1</mn></mrow></math>.
+(Try to find a counterexample!)</p>
+</div>
+<div id="S3.SS3.p5" class="ltx_para ltx_noindent">
+<p id="S3.SS3.p5.4" class="ltx_p">Here’s a fun fact: for any given finite-dimensional vector space <math id="S3.SS3.p5.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>, all norms on <math id="S3.SS3.p5.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> are equivalent in the sense that for two norms <math id="S3.SS3.p5.3.m3" class="ltx_Math" alttext="\|\cdot\|_{A},\|\cdot\|_{B}" display="inline"><mrow><mo>∥</mo><mo>⋅</mo><msub><mo>∥</mo><mi>A</mi></msub><mo>,</mo><mo>∥</mo><mo>⋅</mo><msub><mo>∥</mo><mi>B</mi></msub></mrow></math>, there exist constants <math id="S3.SS3.p5.4.m4" class="ltx_Math" alttext="\alpha,\beta&gt;0" display="inline"><mrow><mrow><mi>α</mi><mo>,</mo><mi>β</mi></mrow><mo>&gt;</mo><mn>0</mn></mrow></math> such that</p>
+<table id="S3.Ex11" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex11.m1" class="ltx_Math" alttext="\alpha\|\mathbf{x}\|_{A}\leq\|\mathbf{x}\|_{B}\leq\beta\|\mathbf{x}\|_{A}" display="block"><mrow><mrow><mi>α</mi><mo>⁢</mo><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mi>A</mi></msub></mrow><mo>≤</mo><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mi>B</mi></msub><mo>≤</mo><mrow><mi>β</mi><mo>⁢</mo><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mi>A</mi></msub></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS3.p5.5" class="ltx_p">for all <math id="S3.SS3.p5.5.m1" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>. Therefore convergence in one norm implies convergence in any other norm.
+This rule may not apply in infinite-dimensional vector spaces such as function spaces, though.</p>
+</div>
+</section>
+<section id="S3.SS4" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.4 </span>Inner product spaces</h3>
+
+<div id="S3.SS4.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS4.p1.2" class="ltx_p">An <span id="S3.SS4.p1.2.1" class="ltx_text ltx_font_bold">inner product</span> on a real vector space <math id="S3.SS4.p1.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> is a function <math id="S3.SS4.p1.2.m2" class="ltx_Math" alttext="\langle\cdot,\cdot\rangle\mathrel{\mathop{:}}V\times V\to\mathbb{R}" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mo>⋅</mo><mo>,</mo><mo>⋅</mo><mo stretchy="false">⟩</mo></mrow><mo>:</mo><mrow><mi>V</mi><mo>×</mo><mi>V</mi></mrow><mo>→</mo><mi>ℝ</mi></mrow></math> satisfying</p>
+<ol id="S3.I5" class="ltx_enumerate">
+<li id="S3.I5.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I5.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I5.i1.p1.2" class="ltx_p"><math id="S3.I5.i1.p1.1.m1" class="ltx_Math" alttext="\langle\mathbf{x},\mathbf{x}\rangle\geq 0" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐱</mi><mo stretchy="false">⟩</mo></mrow><mo>≥</mo><mn>0</mn></mrow></math>, with equality if and only if <math id="S3.I5.i1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math></p>
+</div>
+</li>
+<li id="S3.I5.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I5.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I5.i2.p1.1" class="ltx_p"><math id="S3.I5.i2.p1.1.m1" class="ltx_Math" alttext="\langle\alpha\mathbf{x}+\beta\mathbf{y},\mathbf{z}\rangle=\alpha\langle\mathbf%
+{x},\mathbf{z}\rangle+\beta\langle\mathbf{y},\mathbf{z}\rangle" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo>,</mo><mi>𝐳</mi><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐳</mi><mo stretchy="false">⟩</mo></mrow></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐲</mi><mo>,</mo><mi>𝐳</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I5.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I5.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I5.i3.p1.1" class="ltx_p"><math id="S3.I5.i3.p1.1.m1" class="ltx_Math" alttext="\langle\mathbf{x},\mathbf{y}\rangle=\langle\mathbf{y},\mathbf{x}\rangle" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐲</mi><mo>,</mo><mi>𝐱</mi><mo stretchy="false">⟩</mo></mrow></mrow></math></p>
+</div>
+</li>
+</ol>
+<p id="S3.SS4.p1.4" class="ltx_p">for all <math id="S3.SS4.p1.3.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y},\mathbf{z}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo>,</mo><mi>𝐳</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math> and all <math id="S3.SS4.p1.4.m2" class="ltx_Math" alttext="\alpha,\beta\in\mathbb{R}" display="inline"><mrow><mrow><mi>α</mi><mo>,</mo><mi>β</mi></mrow><mo>∈</mo><mi>ℝ</mi></mrow></math>.
+A vector space endowed with an inner product is called an <span id="S3.SS4.p1.4.1" class="ltx_text ltx_font_bold">inner product space</span>.</p>
+</div>
+<div id="S3.SS4.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS4.p2.2" class="ltx_p">Note that any inner product on <math id="S3.SS4.p2.1.m1" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math> induces a norm on <math id="S3.SS4.p2.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>:</p>
+<table id="S3.Ex12" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex12.m1" class="ltx_Math" alttext="\|\mathbf{x}\|=\sqrt{\langle\mathbf{x},\mathbf{x}\rangle}" display="block"><mrow><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mo>=</mo><msqrt><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐱</mi><mo stretchy="false">⟩</mo></mrow></msqrt></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS4.p2.3" class="ltx_p">One can verify that the axioms for norms are satisfied under this definition and follow (almost) directly from the axioms for inner products.
+Therefore any inner product space is also a normed space (and hence also a metric space).<span id="footnote4" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">4</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">4</sup><span class="ltx_tag ltx_tag_note">4</span>
+If an inner product space is complete with respect to the distance metric induced by its inner product, we say that it is a <span id="footnote4.1" class="ltx_text ltx_font_bold">Hilbert space</span>.
+</span></span></span></p>
+</div>
+<div id="S3.SS4.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS4.p3.7" class="ltx_p">Two vectors <math id="S3.SS4.p3.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> and <math id="S3.SS4.p3.2.m2" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> are said to be <span id="S3.SS4.p3.7.1" class="ltx_text ltx_font_bold">orthogonal</span> if <math id="S3.SS4.p3.3.m3" class="ltx_Math" alttext="\langle\mathbf{x},\mathbf{y}\rangle=0" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mn>0</mn></mrow></math>; we write <math id="S3.SS4.p3.4.m4" class="ltx_Math" alttext="\mathbf{x}\perp\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo>⟂</mo><mi>𝐲</mi></mrow></math> for shorthand.
+Orthogonality generalizes the notion of perpendicularity from Euclidean space.
+If two orthogonal vectors <math id="S3.SS4.p3.5.m5" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> and <math id="S3.SS4.p3.6.m6" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> additionally have unit length (i.e. <math id="S3.SS4.p3.7.m7" class="ltx_Math" alttext="\|\mathbf{x}\|=\|\mathbf{y}\|=1" display="inline"><mrow><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mo>=</mo><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow><mo>=</mo><mn>1</mn></mrow></math>), then they are described as <span id="S3.SS4.p3.7.2" class="ltx_text ltx_font_bold">orthonormal</span>.</p>
+</div>
+<div id="S3.SS4.p4" class="ltx_para ltx_noindent">
+<p id="S3.SS4.p4.1" class="ltx_p">The standard inner product on <math id="S3.SS4.p4.1.m1" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> is given by
+</p>
+<table id="S3.Ex13" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex13.m1" class="ltx_Math" alttext="\langle\mathbf{x},\mathbf{y}\rangle=\sum_{i=1}^{n}x_{i}y_{i}=\mathbf{x}^{\!%
+\top\!}\mathbf{y}" display="block"><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>x</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>y</mi><mi>i</mi></msub></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐲</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS4.p4.6" class="ltx_p">The matrix notation on the righthand side (see the Transposition section if it’s unfamiliar) arises because this inner product is a special case of matrix multiplication where we regard the resulting <math id="S3.SS4.p4.2.m1" class="ltx_Math" alttext="1\times 1" display="inline"><mrow><mn>1</mn><mo>×</mo><mn>1</mn></mrow></math> matrix as a scalar.
+The inner product on <math id="S3.SS4.p4.3.m2" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> is also often written <math id="S3.SS4.p4.4.m3" class="ltx_Math" alttext="\mathbf{x}\cdot\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo>⋅</mo><mi>𝐲</mi></mrow></math> (hence the alternate name <span id="S3.SS4.p4.6.1" class="ltx_text ltx_font_bold">dot product</span>).
+The reader can verify that the two-norm <math id="S3.SS4.p4.5.m4" class="ltx_Math" alttext="\|\cdot\|_{2}" display="inline"><mrow><mo>∥</mo><mo>⋅</mo><msub><mo>∥</mo><mn>2</mn></msub></mrow></math> on <math id="S3.SS4.p4.6.m5" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> is induced by this inner product.</p>
+</div>
+<section id="S3.SS4.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.4.1 </span>Pythagorean Theorem</h4>
+
+<div id="S3.SS4.SSS1.p1" class="ltx_para">
+<p id="S3.SS4.SSS1.p1.1" class="ltx_p">The well-known Pythagorean theorem generalizes naturally to arbitrary inner product spaces.</p>
+</div>
+<div id="Thmtheorem1" class="ltx_theorem ltx_theorem_theorem">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmtheorem1.1.1.1" class="ltx_text ltx_font_bold">Theorem 1</span></span><span id="Thmtheorem1.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmtheorem1.p1" class="ltx_para">
+<p id="Thmtheorem1.p1.1" class="ltx_p"><span id="Thmtheorem1.p1.1.1" class="ltx_text ltx_font_italic">If <math id="Thmtheorem1.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}\perp\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo mathvariant="normal">⟂</mo><mi>𝐲</mi></mrow></math>, then</span></p>
+<table id="S3.Ex14" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex14.m1" class="ltx_Math" alttext="\|\mathbf{x}+\mathbf{y}\|^{2}=\|\mathbf{x}\|^{2}+\|\mathbf{y}\|^{2}" display="block"><mrow><msup><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mn>2</mn></msup><mo>=</mo><mrow><msup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msup><mo>+</mo><msup><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow><mn>2</mn></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S3.SS4.SSS1.1" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS4.SSS1.1.p1" class="ltx_para">
+<p id="S3.SS4.SSS1.1.p1.2" class="ltx_p">Suppose <math id="S3.SS4.SSS1.1.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}\perp\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo>⟂</mo><mi>𝐲</mi></mrow></math>, i.e. <math id="S3.SS4.SSS1.1.p1.2.m2" class="ltx_Math" alttext="\langle\mathbf{x},\mathbf{y}\rangle=0" display="inline"><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mn>0</mn></mrow></math>. Then</p>
+<table id="S3.Ex15" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex15.m1" class="ltx_Math" alttext="\|\mathbf{x}+\mathbf{y}\|^{2}=\langle\mathbf{x}+\mathbf{y},\mathbf{x}+\mathbf{%
+y}\rangle=\langle\mathbf{x},\mathbf{x}\rangle+\langle\mathbf{y},\mathbf{x}%
+\rangle+\langle\mathbf{x},\mathbf{y}\rangle+\langle\mathbf{y},\mathbf{y}%
+\rangle=\|\mathbf{x}\|^{2}+\|\mathbf{y}\|^{2}" display="block"><mrow><msup><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mn>2</mn></msup><mo>=</mo><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo>,</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐲</mi></mrow><mo stretchy="false">⟩</mo></mrow><mo>=</mo><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐱</mi><mo stretchy="false">⟩</mo></mrow><mo>+</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐲</mi><mo>,</mo><mi>𝐱</mi><mo stretchy="false">⟩</mo></mrow><mo>+</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo>+</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐲</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow></mrow><mo>=</mo><mrow><msup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msup><mo>+</mo><msup><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow><mn>2</mn></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS4.SSS1.1.p1.3" class="ltx_p">as claimed.
+∎</p>
+</div>
+</div>
+</section>
+<section id="S3.SS4.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.4.2 </span>Cauchy-Schwarz inequality</h4>
+
+<div id="S3.SS4.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS4.SSS2.p1.4" class="ltx_p">This inequality is sometimes useful in proving bounds:</p>
+<table id="S3.Ex16" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex16.m1" class="ltx_Math" alttext="|\langle\mathbf{x},\mathbf{y}\rangle|\leq\|\mathbf{x}\|\cdot\|\mathbf{y}\|" display="block"><mrow><mrow><mo stretchy="false">|</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi><mo stretchy="false">⟩</mo></mrow><mo stretchy="false">|</mo></mrow><mo>≤</mo><mrow><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mo>⋅</mo><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS4.SSS2.p1.3" class="ltx_p">for all <math id="S3.SS4.SSS2.p1.1.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math>. Equality holds exactly when <math id="S3.SS4.SSS2.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> and <math id="S3.SS4.SSS2.p1.3.m3" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> are scalar multiples of each other (or equivalently, when they are linearly dependent).</p>
+</div>
+</section>
+</section>
+<section id="S3.SS5" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.5 </span>Transposition</h3>
+
+<div id="S3.SS5.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS5.p1.8" class="ltx_p">If <math id="S3.SS5.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{m\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math>, its <span id="S3.SS5.p1.8.1" class="ltx_text ltx_font_bold">transpose</span> <math id="S3.SS5.p1.2.m2" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\in\mathbb{R}^{n\times m}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>m</mi></mrow></msup></mrow></math> is given by <math id="S3.SS5.p1.3.m3" class="ltx_Math" alttext="(\mathbf{A}^{\!\top\!})_{ij}=A_{ji}" display="inline"><mrow><msub><mrow><mo stretchy="false">(</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo stretchy="false">)</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><msub><mi>A</mi><mrow><mi>j</mi><mo>⁢</mo><mi>i</mi></mrow></msub></mrow></math> for each <math id="S3.SS5.p1.4.m4" class="ltx_Math" alttext="(i,j)" display="inline"><mrow><mo stretchy="false">(</mo><mi>i</mi><mo>,</mo><mi>j</mi><mo stretchy="false">)</mo></mrow></math>.
+In other words, the columns of <math id="S3.SS5.p1.5.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> become the rows of <math id="S3.SS5.p1.6.m6" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>, and the rows of <math id="S3.SS5.p1.7.m7" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> become the columns of <math id="S3.SS5.p1.8.m8" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>.
+</p>
+</div>
+<div id="S3.SS5.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS5.p2.1" class="ltx_p">The transpose has several nice algebraic properties that can be easily verified from the definition:</p>
+<ol id="S3.I6" class="ltx_enumerate">
+<li id="S3.I6.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I6.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I6.i1.p1.1" class="ltx_p"><math id="S3.I6.i1.p1.1.m1" class="ltx_Math" alttext="(\mathbf{A}^{\!\top\!})^{\!\top\!}=\mathbf{A}" display="inline"><mrow><msup><mrow><mo stretchy="false">(</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><mi>𝐀</mi></mrow></math></p>
+</div>
+</li>
+<li id="S3.I6.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I6.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I6.i2.p1.1" class="ltx_p"><math id="S3.I6.i2.p1.1.m1" class="ltx_Math" alttext="(\mathbf{A}+\mathbf{B})^{\!\top\!}=\mathbf{A}^{\!\top\!}+\mathbf{B}^{\!\top\!}" display="inline"><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀</mi><mo>+</mo><mi>𝐁</mi></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>+</mo><msup><mi>𝐁</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I6.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I6.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I6.i3.p1.1" class="ltx_p"><math id="S3.I6.i3.p1.1.m1" class="ltx_Math" alttext="(\alpha\mathbf{A})^{\!\top\!}=\alpha\mathbf{A}^{\!\top\!}" display="inline"><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐀</mi></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><mrow><mi>α</mi><mo>⁢</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I6.i4" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iv)</span> 
+<div id="S3.I6.i4.p1" class="ltx_para ltx_noindent">
+<p id="S3.I6.i4.p1.1" class="ltx_p"><math id="S3.I6.i4.p1.1.m1" class="ltx_Math" alttext="(\mathbf{A}\mathbf{B})^{\!\top\!}=\mathbf{B}^{\!\top\!}\mathbf{A}^{\!\top\!}" display="inline"><mrow><msup><mrow><mo stretchy="false">(</mo><mi>𝐀𝐁</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><mrow><msup><mi>𝐁</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></p>
+</div>
+</li>
+</ol>
+</div>
+</section>
+<section id="S3.SS6" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.6 </span>Eigenthings</h3>
+
+<div id="S3.SS6.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS6.p1.5" class="ltx_p">For a square matrix <math id="S3.SS6.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math>, there may be vectors which, when <math id="S3.SS6.p1.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is applied to them, are simply scaled by some constant.
+We say that a nonzero vector <math id="S3.SS6.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math> is an <span id="S3.SS6.p1.5.1" class="ltx_text ltx_font_bold">eigenvector</span> of <math id="S3.SS6.p1.4.m4" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> corresponding to <span id="S3.SS6.p1.5.2" class="ltx_text ltx_font_bold">eigenvalue</span> <math id="S3.SS6.p1.5.m5" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math> if</p>
+<table id="S3.Ex17" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex17.m1" class="ltx_Math" alttext="\mathbf{A}\mathbf{x}=\lambda\mathbf{x}" display="block"><mrow><mi>𝐀𝐱</mi><mo>=</mo><mrow><mi>λ</mi><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS6.p1.7" class="ltx_p">The zero vector is excluded from this definition because <math id="S3.SS6.p1.6.m1" class="ltx_Math" alttext="\mathbf{A}\mathbf{0}=\mathbf{0}=\lambda\mathbf{0}" display="inline"><mrow><mi>𝐀𝟎</mi><mo>=</mo><mn>𝟎</mn><mo>=</mo><mrow><mi>λ</mi><mo>⁢</mo><mn>𝟎</mn></mrow></mrow></math> for every <math id="S3.SS6.p1.7.m2" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math>.</p>
+</div>
+<div id="S3.SS6.p2" class="ltx_para">
+<p id="S3.SS6.p2.1" class="ltx_p">We now give some useful results about how eigenvalues change after various manipulations.</p>
+</div>
+<div id="Thmproposition1" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition1.1.1.1" class="ltx_text ltx_font_bold">Proposition 1</span></span><span id="Thmproposition1.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition1.p1" class="ltx_para">
+<p id="Thmproposition1.p1.3" class="ltx_p"><span id="Thmproposition1.p1.3.3" class="ltx_text ltx_font_italic">Let <math id="Thmproposition1.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> be an eigenvector of <math id="Thmproposition1.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> with corresponding eigenvalue <math id="Thmproposition1.p1.3.3.m3" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math>.
+Then</span></p>
+<ol id="S3.I7" class="ltx_enumerate">
+<li id="S3.I7.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S3.I7.i1.1.1.1" class="ltx_text">(i)</span></span> 
+<div id="S3.I7.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I7.i1.p1.4" class="ltx_p"><span id="S3.I7.i1.p1.4.1" class="ltx_text ltx_font_italic">For any </span><math id="S3.I7.i1.p1.1.m1" class="ltx_Math" alttext="\gamma\in\mathbb{R}" display="inline"><mrow><mi>γ</mi><mo>∈</mo><mi>ℝ</mi></mrow></math><span id="S3.I7.i1.p1.4.2" class="ltx_text ltx_font_italic">, </span><math id="S3.I7.i1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math><span id="S3.I7.i1.p1.4.3" class="ltx_text ltx_font_italic"> is an eigenvector of </span><math id="S3.I7.i1.p1.3.m3" class="ltx_Math" alttext="\mathbf{A}+\gamma\mathbf{I}" display="inline"><mrow><mi>𝐀</mi><mo>+</mo><mrow><mi>γ</mi><mo>⁢</mo><mi>𝐈</mi></mrow></mrow></math><span id="S3.I7.i1.p1.4.4" class="ltx_text ltx_font_italic"> with eigenvalue </span><math id="S3.I7.i1.p1.4.m4" class="ltx_Math" alttext="\lambda+\gamma" display="inline"><mrow><mi>λ</mi><mo>+</mo><mi>γ</mi></mrow></math><span id="S3.I7.i1.p1.4.5" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+<li id="S3.I7.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S3.I7.i2.1.1.1" class="ltx_text">(ii)</span></span> 
+<div id="S3.I7.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I7.i2.p1.4" class="ltx_p"><span id="S3.I7.i2.p1.4.1" class="ltx_text ltx_font_italic">If </span><math id="S3.I7.i2.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math><span id="S3.I7.i2.p1.4.2" class="ltx_text ltx_font_italic"> is invertible, then </span><math id="S3.I7.i2.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math><span id="S3.I7.i2.p1.4.3" class="ltx_text ltx_font_italic"> is an eigenvector of </span><math id="S3.I7.i2.p1.3.m3" class="ltx_Math" alttext="\mathbf{A}^{-1}" display="inline"><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math><span id="S3.I7.i2.p1.4.4" class="ltx_text ltx_font_italic"> with eigenvalue </span><math id="S3.I7.i2.p1.4.m4" class="ltx_Math" alttext="\lambda^{-1}" display="inline"><msup><mi>λ</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math><span id="S3.I7.i2.p1.4.5" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+<li id="S3.I7.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S3.I7.i3.1.1.1" class="ltx_text">(iii)</span></span> 
+<div id="S3.I7.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I7.i3.p1.3" class="ltx_p"><math id="S3.I7.i3.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}^{k}\mathbf{x}=\lambda^{k}\mathbf{x}" display="inline"><mrow><mrow><msup><mi>𝐀</mi><mi>k</mi></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>λ</mi><mi>k</mi></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math><span id="S3.I7.i3.p1.3.1" class="ltx_text ltx_font_italic"> for any </span><math id="S3.I7.i3.p1.2.m2" class="ltx_Math" alttext="k\in\mathbb{Z}" display="inline"><mrow><mi>k</mi><mo>∈</mo><mi>ℤ</mi></mrow></math><span id="S3.I7.i3.p1.3.2" class="ltx_text ltx_font_italic"> (where </span><math id="S3.I7.i3.p1.3.m3" class="ltx_Math" alttext="\mathbf{A}^{0}=\mathbf{I}" display="inline"><mrow><msup><mi>𝐀</mi><mn>0</mn></msup><mo>=</mo><mi>𝐈</mi></mrow></math><span id="S3.I7.i3.p1.3.3" class="ltx_text ltx_font_italic"> by definition).</span></p>
+</div>
+</li>
+</ol>
+</div>
+</div>
+<div id="S3.SS6.3" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS6.1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS6.1.p1.1" class="ltx_p">(i) follows readily:</p>
+<table id="S3.Ex18" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex18.m1" class="ltx_Math" alttext="(\mathbf{A}+\gamma\mathbf{I})\mathbf{x}=\mathbf{A}\mathbf{x}+\gamma\mathbf{I}%
+\mathbf{x}=\lambda\mathbf{x}+\gamma\mathbf{x}=(\lambda+\gamma)\mathbf{x}" display="block"><mrow><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀</mi><mo>+</mo><mrow><mi>γ</mi><mo>⁢</mo><mi>𝐈</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mi>𝐀𝐱</mi><mo>+</mo><mrow><mi>γ</mi><mo>⁢</mo><mi>𝐈𝐱</mi></mrow></mrow><mo>=</mo><mrow><mrow><mi>λ</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mi>γ</mi><mo>⁢</mo><mi>𝐱</mi></mrow></mrow><mo>=</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>λ</mi><mo>+</mo><mi>γ</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<div id="S3.SS6.2.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS6.2.p2.1" class="ltx_p">(ii) Suppose <math id="S3.SS6.2.p2.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is invertible. Then</p>
+<table id="S3.Ex19" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex19.m1" class="ltx_Math" alttext="\mathbf{x}=\mathbf{A}^{-1}\mathbf{A}\mathbf{x}=\mathbf{A}^{-1}(\lambda\mathbf{%
+x})=\lambda\mathbf{A}^{-1}\mathbf{x}" display="block"><mrow><mi>𝐱</mi><mo>=</mo><mrow><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>λ</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>λ</mi><mo>⁢</mo><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS6.2.p2.5" class="ltx_p">Dividing by <math id="S3.SS6.2.p2.2.m1" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math>, which is valid because the invertibility of <math id="S3.SS6.2.p2.3.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> implies <math id="S3.SS6.2.p2.4.m3" class="ltx_Math" alttext="\lambda\neq 0" display="inline"><mrow><mi>λ</mi><mo>≠</mo><mn>0</mn></mrow></math>, gives <math id="S3.SS6.2.p2.5.m4" class="ltx_Math" alttext="\lambda^{-1}\mathbf{x}=\mathbf{A}^{-1}\mathbf{x}" display="inline"><mrow><mrow><msup><mi>λ</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math>.</p>
+</div>
+<div id="S3.SS6.3.p3" class="ltx_para">
+<p id="S3.SS6.3.p3.4" class="ltx_p">(iii) The case <math id="S3.SS6.3.p3.1.m1" class="ltx_Math" alttext="k\geq 0" display="inline"><mrow><mi>k</mi><mo>≥</mo><mn>0</mn></mrow></math> follows immediately by induction on <math id="S3.SS6.3.p3.2.m2" class="ltx_Math" alttext="k" display="inline"><mi>k</mi></math>.
+Then the general case <math id="S3.SS6.3.p3.3.m3" class="ltx_Math" alttext="k\in\mathbb{Z}" display="inline"><mrow><mi>k</mi><mo>∈</mo><mi>ℤ</mi></mrow></math> follows by combining the <math id="S3.SS6.3.p3.4.m4" class="ltx_Math" alttext="k\geq 0" display="inline"><mrow><mi>k</mi><mo>≥</mo><mn>0</mn></mrow></math> case with (ii).
+∎</p>
+</div>
+</div>
+</section>
+<section id="S3.SS7" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.7 </span>Trace</h3>
+
+<div id="S3.SS7.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS7.p1.2" class="ltx_p">The <span id="S3.SS7.p1.2.1" class="ltx_text ltx_font_bold">trace</span> of a square matrix is the sum of its diagonal entries:</p>
+<table id="S3.Ex20" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex20.m1" class="ltx_Math" alttext="\tr(\mathbf{A})=\sum_{i=1}^{n}A_{ii}" display="block"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><msub><mi>A</mi><mrow><mi>i</mi><mo>⁢</mo><mi>i</mi></mrow></msub></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS7.p1.3" class="ltx_p">The trace has several nice algebraic properties:</p>
+<ol id="S3.I8" class="ltx_enumerate">
+<li id="S3.I8.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I8.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I8.i1.p1.1" class="ltx_p"><math id="S3.I8.i1.p1.1.m1" class="ltx_Math" alttext="\tr(\mathbf{A}+\mathbf{B})=\tr(\mathbf{A})+\tr(\mathbf{B})" display="inline"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mi>𝐀</mi><mo>+</mo><mi>𝐁</mi></mrow><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mo>+</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐁</mi><mo>)</mo></mrow></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I8.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I8.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I8.i2.p1.1" class="ltx_p"><math id="S3.I8.i2.p1.1.m1" class="ltx_Math" alttext="\tr(\alpha\mathbf{A})=\alpha\tr(\mathbf{A})" display="inline"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐀</mi></mrow><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>α</mi><mo>⁢</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I8.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I8.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I8.i3.p1.1" class="ltx_p"><math id="S3.I8.i3.p1.1.m1" class="ltx_Math" alttext="\tr(\mathbf{A}^{\!\top\!})=\tr(\mathbf{A})" display="inline"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I8.i4" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iv)</span> 
+<div id="S3.I8.i4.p1" class="ltx_para ltx_noindent">
+<p id="S3.I8.i4.p1.1" class="ltx_p"><math id="S3.I8.i4.p1.1.m1" class="ltx_Math" alttext="\tr(\mathbf{A}\mathbf{B}\mathbf{C}\mathbf{D})=\tr(\mathbf{B}\mathbf{C}\mathbf{%
+D}\mathbf{A})=\tr(\mathbf{C}\mathbf{D}\mathbf{A}\mathbf{B})=\tr(\mathbf{D}%
+\mathbf{A}\mathbf{B}\mathbf{C})" display="inline"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀𝐁𝐂𝐃</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐁𝐂𝐃𝐀</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐂𝐃𝐀𝐁</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐃𝐀𝐁𝐂</mi><mo>)</mo></mrow></mrow></mrow></math></p>
+</div>
+</li>
+</ol>
+<p id="S3.SS7.p1.1" class="ltx_p">The first three properties follow readily from the definition.
+The last is known as <span id="S3.SS7.p1.1.1" class="ltx_text ltx_font_bold">invariance under cyclic permutations</span>.
+Note that the matrices cannot be reordered arbitrarily, for example <math id="S3.SS7.p1.1.m1" class="ltx_Math" alttext="\tr(\mathbf{A}\mathbf{B}\mathbf{C}\mathbf{D})\neq\tr(\mathbf{B}\mathbf{A}%
+\mathbf{C}\mathbf{D})" display="inline"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀𝐁𝐂𝐃</mi><mo>)</mo></mrow></mrow><mo>≠</mo><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐁𝐀𝐂𝐃</mi><mo>)</mo></mrow></mrow></mrow></math> in general.
+Also, there is nothing special about the product of four matrices – analogous rules hold for more or fewer matrices.</p>
+</div>
+<div id="S3.SS7.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS7.p2.1" class="ltx_p">Interestingly, the trace of a matrix is equal to the sum of its eigenvalues (repeated according to multiplicity):</p>
+<table id="S3.Ex21" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex21.m1" class="ltx_Math" alttext="\tr(\mathbf{A})=\sum_{i}\lambda_{i}(\mathbf{A})" display="block"><mrow><mrow><mi>tr</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>i</mi></munder><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S3.SS8" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.8 </span>Determinant</h3>
+
+<div id="S3.SS8.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS8.p1.1" class="ltx_p">The <span id="S3.SS8.p1.1.1" class="ltx_text ltx_font_bold">determinant</span> of a square matrix can be defined in several different confusing ways, none of which are particularly important for our purposes; go look at an introductory linear algebra text (or Wikipedia) if you need a definition.
+But it’s good to know the properties:</p>
+<ol id="S3.I9" class="ltx_enumerate">
+<li id="S3.I9.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I9.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I9.i1.p1.1" class="ltx_p"><math id="S3.I9.i1.p1.1.m1" class="ltx_Math" alttext="\det(\mathbf{I})=1" display="inline"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐈</mi><mo>)</mo></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math></p>
+</div>
+</li>
+<li id="S3.I9.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I9.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I9.i2.p1.1" class="ltx_p"><math id="S3.I9.i2.p1.1.m1" class="ltx_Math" alttext="\det(\mathbf{A}^{\!\top\!})=\det(\mathbf{A})" display="inline"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I9.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S3.I9.i3.p1" class="ltx_para ltx_noindent">
+<p id="S3.I9.i3.p1.1" class="ltx_p"><math id="S3.I9.i3.p1.1.m1" class="ltx_Math" alttext="\det(\mathbf{A}\mathbf{B})=\det(\mathbf{A})\det(\mathbf{B})" display="inline"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀𝐁</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mo>⁢</mo><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐁</mi><mo>)</mo></mrow></mrow></mrow></mrow></math></p>
+</div>
+</li>
+<li id="S3.I9.i4" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iv)</span> 
+<div id="S3.I9.i4.p1" class="ltx_para ltx_noindent">
+<p id="S3.I9.i4.p1.1" class="ltx_p"><math id="S3.I9.i4.p1.1.m1" class="ltx_Math" alttext="\det(\mathbf{A}^{-1})=\det(\mathbf{A})^{-1}" display="inline"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><msup><mi>𝐀</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>)</mo></mrow></mrow><mo>=</mo><msup><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mrow><mo>-</mo><mn>1</mn></mrow></msup></mrow></math></p>
+</div>
+</li>
+<li id="S3.I9.i5" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(v)</span> 
+<div id="S3.I9.i5.p1" class="ltx_para ltx_noindent">
+<p id="S3.I9.i5.p1.1" class="ltx_p"><math id="S3.I9.i5.p1.1.m1" class="ltx_Math" alttext="\det(\alpha\mathbf{A})=\alpha^{n}\det(\mathbf{A})" display="inline"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐀</mi></mrow><mo>)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>α</mi><mi>n</mi></msup><mo>⁢</mo><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow></mrow></mrow></math></p>
+</div>
+</li>
+</ol>
+<p id="S3.SS8.p1.2" class="ltx_p">Interestingly, the determinant of a matrix is equal to the product of its eigenvalues (repeated according to multiplicity):</p>
+<table id="S3.Ex22" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex22.m1" class="ltx_Math" alttext="\det(\mathbf{A})=\prod_{i}\lambda_{i}(\mathbf{A})" display="block"><mrow><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝐀</mi><mo>)</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mi>i</mi></munder><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S3.SS9" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.9 </span>Orthogonal matrices</h3>
+
+<div id="S3.SS9.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS9.p1.1" class="ltx_p">A matrix <math id="S3.SS9.p1.1.m1" class="ltx_Math" alttext="\mathbf{Q}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐐</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> is said to be <span id="S3.SS9.p1.1.1" class="ltx_text ltx_font_bold">orthogonal</span> if its columns are pairwise orthonormal.
+This definition implies that</p>
+<table id="S3.Ex23" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex23.m1" class="ltx_Math" alttext="\mathbf{Q}^{\!\top\!}\mathbf{Q}=\mathbf{Q}\mathbf{Q}^{\!\top\!}=\mathbf{I}" display="block"><mrow><mrow><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐐</mi></mrow><mo>=</mo><msup><mi>𝐐𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><mi>𝐈</mi></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS9.p1.2" class="ltx_p">or equivalently, <math id="S3.SS9.p1.2.m1" class="ltx_Math" alttext="\mathbf{Q}^{\!\top\!}=\mathbf{Q}^{-1}" display="inline"><mrow><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>=</mo><msup><mi>𝐐</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></mrow></math>. A nice thing about orthogonal matrices is that they preserve inner products:</p>
+<table id="S3.Ex24" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex24.m1" class="ltx_Math" alttext="(\mathbf{Q}\mathbf{x})^{\!\top\!}(\mathbf{Q}\mathbf{y})=\mathbf{x}^{\!\top\!}%
+\mathbf{Q}^{\!\top\!}\mathbf{Q}\mathbf{y}=\mathbf{x}^{\!\top\!}\mathbf{I}%
+\mathbf{y}=\mathbf{x}^{\!\top\!}\mathbf{y}" display="block"><mrow><mrow><msup><mrow><mo stretchy="false">(</mo><mi>𝐐𝐱</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐐𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐐𝐲</mi></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐈𝐲</mi></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐲</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS9.p1.3" class="ltx_p">A direct result of this fact is that they also preserve 2-norms:
+</p>
+<table id="S3.Ex25" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex25.m1" class="ltx_Math" alttext="\|\mathbf{Q}\mathbf{x}\|_{2}=\sqrt{(\mathbf{Q}\mathbf{x})^{\!\top\!}(\mathbf{Q%
+}\mathbf{x})}=\sqrt{\mathbf{x}^{\!\top\!}\mathbf{x}}=\|\mathbf{x}\|_{2}" display="block"><mrow><msub><mrow><mo>∥</mo><mi>𝐐𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><msqrt><mrow><msup><mrow><mo stretchy="false">(</mo><mi>𝐐𝐱</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐐𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></msqrt><mo>=</mo><msqrt><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow></msqrt><mo>=</mo><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS9.p1.4" class="ltx_p">Therefore multiplication by an orthogonal matrix can be considered as a transformation that preserves length, but may rotate or reflect the vector about the origin.</p>
+</div>
+</section>
+<section id="S3.SS10" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.10 </span>Symmetric matrices</h3>
+
+<div id="S3.SS10.p1" class="ltx_para">
+<p id="S3.SS10.p1.4" class="ltx_p">A matrix <math id="S3.SS10.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> is said to be <span id="S3.SS10.p1.4.1" class="ltx_text ltx_font_bold">symmetric</span> if it is equal to its own transpose (<math id="S3.SS10.p1.2.m2" class="ltx_Math" alttext="\mathbf{A}=\mathbf{A}^{\!\top\!}" display="inline"><mrow><mi>𝐀</mi><mo>=</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></math>), meaning that <math id="S3.SS10.p1.3.m3" class="ltx_Math" alttext="A_{ij}=A_{ji}" display="inline"><mrow><msub><mi>A</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><msub><mi>A</mi><mrow><mi>j</mi><mo>⁢</mo><mi>i</mi></mrow></msub></mrow></math> for all <math id="S3.SS10.p1.4.m4" class="ltx_Math" alttext="(i,j)" display="inline"><mrow><mo stretchy="false">(</mo><mi>i</mi><mo>,</mo><mi>j</mi><mo stretchy="false">)</mo></mrow></math>.
+This definition seems harmless enough but turns out to have some strong implications.
+We summarize the most important of these as</p>
+</div>
+<div id="Thmtheorem2" class="ltx_theorem ltx_theorem_theorem">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmtheorem2.1.1.1" class="ltx_text ltx_font_bold">Theorem 2</span></span><span id="Thmtheorem2.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmtheorem2.p1" class="ltx_para">
+<p id="Thmtheorem2.p1.3" class="ltx_p"><span id="Thmtheorem2.p1.3.3" class="ltx_text ltx_font_italic">(Spectral Theorem)
+If <math id="Thmtheorem2.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐀</mi><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo mathvariant="normal">×</mo><mi>n</mi></mrow></msup></mrow></math> is symmetric, then there exists an orthonormal basis for <math id="Thmtheorem2.p1.2.2.m2" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math> consisting of eigenvectors of <math id="Thmtheorem2.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>.</span></p>
+</div>
+</div>
+<div id="S3.SS10.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS10.p2.7" class="ltx_p">The practical application of this theorem is a particular factorization of symmetric matrices, referred to as the <span id="S3.SS10.p2.7.1" class="ltx_text ltx_font_bold">eigendecomposition</span> or <span id="S3.SS10.p2.7.2" class="ltx_text ltx_font_bold">spectral decomposition</span>.
+Denote the orthonormal basis of eigenvectors <math id="S3.SS10.p2.1.m1" class="ltx_Math" alttext="\mathbf{q}_{1},\dots,\mathbf{q}_{n}" display="inline"><mrow><msub><mi>𝐪</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>𝐪</mi><mi>n</mi></msub></mrow></math> and their eigenvalues <math id="S3.SS10.p2.2.m2" class="ltx_Math" alttext="\lambda_{1},\dots,\lambda_{n}" display="inline"><mrow><msub><mi>λ</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>λ</mi><mi>n</mi></msub></mrow></math>.
+Let <math id="S3.SS10.p2.3.m3" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math> be an orthogonal matrix with <math id="S3.SS10.p2.4.m4" class="ltx_Math" alttext="\mathbf{q}_{1},\dots,\mathbf{q}_{n}" display="inline"><mrow><msub><mi>𝐪</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>𝐪</mi><mi>n</mi></msub></mrow></math> as its columns, and <math id="S3.SS10.p2.5.m5" class="ltx_Math" alttext="\mathbf{\Lambda}=\operatorname*{diag}(\lambda_{1},\dots,\lambda_{n})" display="inline"><mrow><mi>𝚲</mi><mo>=</mo><mrow><mo>diag</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>λ</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>λ</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+Since by definition <math id="S3.SS10.p2.6.m6" class="ltx_Math" alttext="\mathbf{A}\mathbf{q}_{i}=\lambda_{i}\mathbf{q}_{i}" display="inline"><mrow><msub><mi>𝐀𝐪</mi><mi>i</mi></msub><mo>=</mo><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>𝐪</mi><mi>i</mi></msub></mrow></mrow></math> for every <math id="S3.SS10.p2.7.m7" class="ltx_Math" alttext="i" display="inline"><mi>i</mi></math>, the following relationship holds:</p>
+<table id="S3.Ex26" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex26.m1" class="ltx_Math" alttext="\mathbf{A}\mathbf{Q}=\mathbf{Q}\mathbf{\Lambda}" display="block"><mrow><mi>𝐀𝐐</mi><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><mi>𝚲</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS10.p2.8" class="ltx_p">Right-multiplying by <math id="S3.SS10.p2.8.m1" class="ltx_Math" alttext="\mathbf{Q}^{\!\top\!}" display="inline"><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>, we arrive at the decomposition</p>
+<table id="S3.Ex27" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex27.m1" class="ltx_Math" alttext="\mathbf{A}=\mathbf{Q}\mathbf{\Lambda}\mathbf{Q}^{\!\top\!}" display="block"><mrow><mi>𝐀</mi><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><mi>𝚲</mi><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<section id="S3.SS10.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.10.1 </span>Rayleigh quotients</h4>
+
+<div id="S3.SS10.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS10.SSS1.p1.2" class="ltx_p">Let <math id="S3.SS10.SSS1.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> be a symmetric matrix.
+The expression <math id="S3.SS10.SSS1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></math> is called a <span id="S3.SS10.SSS1.p1.2.1" class="ltx_text ltx_font_bold">quadratic form</span>.</p>
+</div>
+<div id="S3.SS10.SSS1.p2" class="ltx_para">
+<p id="S3.SS10.SSS1.p2.2" class="ltx_p">There turns out to be an interesting connection between the quadratic form of a symmetric matrix and its eigenvalues.
+This connection is provided by the <span id="S3.SS10.SSS1.p2.2.1" class="ltx_text ltx_font_bold">Rayleigh quotient</span>
+</p>
+<table id="S3.Ex28" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex28.m1" class="ltx_Math" alttext="R_{\mathbf{A}}(\mathbf{x})=\frac{\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}}{%
+\mathbf{x}^{\!\top\!}\mathbf{x}}" display="block"><mrow><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mfrac><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mfrac></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS10.SSS1.p2.3" class="ltx_p">The Rayleigh quotient has a couple of important properties which the reader can (and should!) easily verify from the definition:</p>
+<ol id="S3.I10" class="ltx_enumerate">
+<li id="S3.I10.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S3.I10.i1.p1" class="ltx_para ltx_noindent">
+<p id="S3.I10.i1.p1.3" class="ltx_p"><span id="S3.I10.i1.p1.3.1" class="ltx_text ltx_font_bold">Scale invariance</span>: for any vector <math id="S3.I10.i1.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mn>𝟎</mn></mrow></math> and any scalar <math id="S3.I10.i1.p1.2.m2" class="ltx_Math" alttext="\alpha\neq 0" display="inline"><mrow><mi>α</mi><mo>≠</mo><mn>0</mn></mrow></math>, <math id="S3.I10.i1.p1.3.m3" class="ltx_Math" alttext="R_{\mathbf{A}}(\mathbf{x})=R_{\mathbf{A}}(\alpha\mathbf{x})" display="inline"><mrow><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.</p>
+</div>
+</li>
+<li id="S3.I10.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S3.I10.i2.p1" class="ltx_para ltx_noindent">
+<p id="S3.I10.i2.p1.4" class="ltx_p">If <math id="S3.I10.i2.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is an eigenvector of <math id="S3.I10.i2.p1.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> with eigenvalue <math id="S3.I10.i2.p1.3.m3" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math>, then <math id="S3.I10.i2.p1.4.m4" class="ltx_Math" alttext="R_{\mathbf{A}}(\mathbf{x})=\lambda" display="inline"><mrow><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mi>λ</mi></mrow></math>.</p>
+</div>
+</li>
+</ol>
+<p id="S3.SS10.SSS1.p2.1" class="ltx_p">We can further show that the Rayleigh quotient is bounded by the largest and smallest eigenvalues of <math id="S3.SS10.SSS1.p2.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>.
+But first we will show a useful special case of the final result.</p>
+</div>
+<div id="Thmproposition2" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition2.1.1.1" class="ltx_text ltx_font_bold">Proposition 2</span></span><span id="Thmproposition2.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition2.p1" class="ltx_para">
+<p id="Thmproposition2.p1.2" class="ltx_p"><span id="Thmproposition2.p1.2.2" class="ltx_text ltx_font_italic">For any <math id="Thmproposition2.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> such that <math id="Thmproposition2.p1.2.2.m2" class="ltx_Math" alttext="\|\mathbf{x}\|_{2}=1" display="inline"><mrow><msub><mrow><mo mathvariant="normal">∥</mo><mi>𝐱</mi><mo mathvariant="normal">∥</mo></mrow><mn mathvariant="normal">2</mn></msub><mo mathvariant="normal">=</mo><mn mathvariant="normal">1</mn></mrow></math>,</span></p>
+<table id="S3.Ex29" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex29.m1" class="ltx_Math" alttext="\lambda_{\min}(\mathbf{A})\leq\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}\leq%
+\lambda_{\max}(\mathbf{A})" display="block"><mrow><mrow><msub><mi>λ</mi><mi>min</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>≤</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmproposition2.p1.3" class="ltx_p"><span id="Thmproposition2.p1.3.1" class="ltx_text ltx_font_italic">with equality if and only if <math id="Thmproposition2.p1.3.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is a corresponding eigenvector.</span></p>
+</div>
+</div>
+<div id="S3.SS10.SSS1.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS10.SSS1.1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS10.SSS1.1.p1.2" class="ltx_p">We show only the <math id="S3.SS10.SSS1.1.p1.1.m1" class="ltx_Math" alttext="\max" display="inline"><mi>max</mi></math> case because the argument for the <math id="S3.SS10.SSS1.1.p1.2.m2" class="ltx_Math" alttext="\min" display="inline"><mi>min</mi></math> case is entirely analogous.</p>
+</div>
+<div id="S3.SS10.SSS1.2.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS10.SSS1.2.p2.7" class="ltx_p">Since <math id="S3.SS10.SSS1.2.p2.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is symmetric, we can decompose it as <math id="S3.SS10.SSS1.2.p2.2.m2" class="ltx_Math" alttext="\mathbf{A}=\mathbf{Q}\mathbf{\Lambda}\mathbf{Q}^{\!\top\!}" display="inline"><mrow><mi>𝐀</mi><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><mi>𝚲</mi><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math>.
+Then use the change of variable <math id="S3.SS10.SSS1.2.p2.3.m3" class="ltx_Math" alttext="\mathbf{y}=\mathbf{Q}^{\!\top\!}\mathbf{x}" display="inline"><mrow><mi>𝐲</mi><mo>=</mo><mrow><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math>, noting that the relationship between <math id="S3.SS10.SSS1.2.p2.4.m4" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> and <math id="S3.SS10.SSS1.2.p2.5.m5" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> is one-to-one and that <math id="S3.SS10.SSS1.2.p2.6.m6" class="ltx_Math" alttext="\|\mathbf{y}\|_{2}=1" display="inline"><mrow><msub><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></math> since <math id="S3.SS10.SSS1.2.p2.7.m7" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math> is orthogonal.
+Hence</p>
+<table id="S3.Ex30" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex30.m1" class="ltx_Math" alttext="\max_{\|\mathbf{x}\|_{2}=1}\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=\max_{\|%
+\mathbf{y}\|_{2}=1}\mathbf{y}^{\!\top\!}\mathbf{\Lambda}\mathbf{y}=\max_{y_{1}%
+^{2}+\dots+y_{n}^{2}=1}\sum_{i=1}^{n}\lambda_{i}y_{i}^{2}" display="block"><mrow><mrow><munder><mi>max</mi><mrow><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></munder><mo>⁡</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></mrow><mo>=</mo><mrow><munder><mi>max</mi><mrow><msub><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></munder><mo>⁡</mo><mrow><msup><mi>𝐲</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝚲</mi><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo>=</mo><mrow><munder><mi>max</mi><mrow><mrow><msubsup><mi>y</mi><mn>1</mn><mn>2</mn></msubsup><mo>+</mo><mi mathvariant="normal">⋯</mi><mo>+</mo><msubsup><mi>y</mi><mi>n</mi><mn>2</mn></msubsup></mrow><mo>=</mo><mn>1</mn></mrow></munder><mo>⁢</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><msubsup><mi>y</mi><mi>i</mi><mn>2</mn></msubsup></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS10.SSS1.2.p2.13" class="ltx_p">Written this way, it is clear that <math id="S3.SS10.SSS1.2.p2.8.m1" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> maximizes this expression exactly if and only if it satisfies <math id="S3.SS10.SSS1.2.p2.9.m2" class="ltx_Math" alttext="\sum_{i\in I}y_{i}^{2}=1" display="inline"><mrow><mrow><msub><mo largeop="true" symmetric="true">∑</mo><mrow><mi>i</mi><mo>∈</mo><mi>I</mi></mrow></msub><msubsup><mi>y</mi><mi>i</mi><mn>2</mn></msubsup></mrow><mo>=</mo><mn>1</mn></mrow></math> where <math id="S3.SS10.SSS1.2.p2.10.m3" class="ltx_Math" alttext="I=\{i\mathrel{\mathop{:}}\lambda_{i}=\max_{j=1,\dots,n}\lambda_{j}=\lambda_{%
+\max}(\mathbf{A})\}" display="inline"><mrow><mi>I</mi><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>i</mi><mo>:</mo><msub><mi>λ</mi><mi>i</mi></msub><mo>=</mo><mrow><msub><mi>max</mi><mrow><mi>j</mi><mo>=</mo><mrow><mn>1</mn><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><mi>n</mi></mrow></mrow></msub><mo>⁡</mo><msub><mi>λ</mi><mi>j</mi></msub></mrow><mo>=</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></math> and <math id="S3.SS10.SSS1.2.p2.11.m4" class="ltx_Math" alttext="y_{j}=0" display="inline"><mrow><msub><mi>y</mi><mi>j</mi></msub><mo>=</mo><mn>0</mn></mrow></math> for <math id="S3.SS10.SSS1.2.p2.12.m5" class="ltx_Math" alttext="j\not\in I" display="inline"><mrow><mi>j</mi><mo>∉</mo><mi>I</mi></mrow></math>.
+That is, <math id="S3.SS10.SSS1.2.p2.13.m6" class="ltx_Math" alttext="I" display="inline"><mi>I</mi></math> contains the index or indices of the largest eigenvalue.
+In this case, the maximal value of the expression is</p>
+<table id="S3.Ex31" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex31.m1" class="ltx_Math" alttext="\sum_{i=1}^{n}\lambda_{i}y_{i}^{2}=\sum_{i\in I}\lambda_{i}y_{i}^{2}=\lambda_{%
+\max}(\mathbf{A})\sum_{i\in I}y_{i}^{2}=\lambda_{\max}(\mathbf{A})" display="block"><mrow><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><msubsup><mi>y</mi><mi>i</mi><mn>2</mn></msubsup></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>∈</mo><mi>I</mi></mrow></munder><mrow><msub><mi>λ</mi><mi>i</mi></msub><mo>⁢</mo><msubsup><mi>y</mi><mi>i</mi><mn>2</mn></msubsup></mrow></mrow><mo>=</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>∈</mo><mi>I</mi></mrow></munder><msubsup><mi>y</mi><mi>i</mi><mn>2</mn></msubsup></mrow></mrow><mo>=</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS10.SSS1.2.p2.15" class="ltx_p">Then writing <math id="S3.SS10.SSS1.2.p2.14.m1" class="ltx_Math" alttext="\mathbf{q}_{1},\dots,\mathbf{q}_{n}" display="inline"><mrow><msub><mi>𝐪</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>𝐪</mi><mi>n</mi></msub></mrow></math> for the columns of <math id="S3.SS10.SSS1.2.p2.15.m2" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math>, we have
+</p>
+<table id="S3.Ex32" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex32.m1" class="ltx_Math" alttext="\mathbf{x}=\mathbf{Q}\mathbf{Q}^{\!\top\!}\mathbf{x}=\mathbf{Q}\mathbf{y}=\sum%
+_{i=1}^{n}y_{i}\mathbf{q}_{i}=\sum_{i\in I}y_{i}\mathbf{q}_{i}" display="block"><mrow><mi>𝐱</mi><mo>=</mo><mrow><msup><mi>𝐐𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mi>𝐐𝐲</mi><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>y</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>𝐪</mi><mi>i</mi></msub></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>∈</mo><mi>I</mi></mrow></munder><mrow><msub><mi>y</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>𝐪</mi><mi>i</mi></msub></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS10.SSS1.2.p2.16" class="ltx_p">where we have used the matrix-vector product identity.</p>
+</div>
+<div id="S3.SS10.SSS1.3.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS10.SSS1.3.p3.8" class="ltx_p">Recall that <math id="S3.SS10.SSS1.3.p3.1.m1" class="ltx_Math" alttext="\mathbf{q}_{1},\dots,\mathbf{q}_{n}" display="inline"><mrow><msub><mi>𝐪</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>𝐪</mi><mi>n</mi></msub></mrow></math> are eigenvectors of <math id="S3.SS10.SSS1.3.p3.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and form an orthonormal basis for <math id="S3.SS10.SSS1.3.p3.3.m3" class="ltx_Math" alttext="\mathbb{R}^{n}" display="inline"><msup><mi>ℝ</mi><mi>n</mi></msup></math>.
+Therefore by construction, the set <math id="S3.SS10.SSS1.3.p3.4.m4" class="ltx_Math" alttext="\{\mathbf{q}_{i}\mathrel{\mathop{:}}i\in I\}" display="inline"><mrow><mo stretchy="false">{</mo><mrow><msub><mi>𝐪</mi><mi>i</mi></msub><mo>:</mo><mi>i</mi><mo>∈</mo><mi>I</mi></mrow><mo stretchy="false">}</mo></mrow></math> forms an orthonormal basis for the eigenspace of <math id="S3.SS10.SSS1.3.p3.5.m5" class="ltx_Math" alttext="\lambda_{\max}(\mathbf{A})" display="inline"><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></math>.
+Hence <math id="S3.SS10.SSS1.3.p3.6.m6" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>, which is a linear combination of these, lies in that eigenspace and thus is an eigenvector of <math id="S3.SS10.SSS1.3.p3.7.m7" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> corresponding to <math id="S3.SS10.SSS1.3.p3.8.m8" class="ltx_Math" alttext="\lambda_{\max}(\mathbf{A})" display="inline"><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></math>.</p>
+</div>
+<div id="S3.SS10.SSS1.4.p4" class="ltx_para">
+<p id="S3.SS10.SSS1.4.p4.3" class="ltx_p">We have shown that <math id="S3.SS10.SSS1.4.p4.1.m1" class="ltx_Math" alttext="\max_{\|\mathbf{x}\|_{2}=1}\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=\lambda_{%
+\max}(\mathbf{A})" display="inline"><mrow><mrow><msub><mi>max</mi><mrow><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></msub><mo>⁡</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></mrow><mo>=</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>, from which we have the general inequality <math id="S3.SS10.SSS1.4.p4.2.m2" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}\leq\lambda_{\max}(\mathbf{A})" display="inline"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>≤</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all unit-length <math id="S3.SS10.SSS1.4.p4.3.m3" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>.
+∎</p>
+</div>
+</div>
+<div id="S3.SS10.SSS1.p3" class="ltx_para">
+<p id="S3.SS10.SSS1.p3.2" class="ltx_p">By the scale invariance of the Rayleigh quotient, we immediately have as a corollary (since <math id="S3.SS10.SSS1.p3.1.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=R_{\mathbf{A}}(\mathbf{x})" display="inline"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>=</mo><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for unit <math id="S3.SS10.SSS1.p3.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>)</p>
+</div>
+<div id="Thmtheorem3" class="ltx_theorem ltx_theorem_theorem">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmtheorem3.1.1.1" class="ltx_text ltx_font_bold">Theorem 3</span></span><span id="Thmtheorem3.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmtheorem3.p1" class="ltx_para">
+<p id="Thmtheorem3.p1.1" class="ltx_p"><span id="Thmtheorem3.p1.1.1" class="ltx_text ltx_font_italic">(Min-max theorem)
+For all <math id="Thmtheorem3.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo mathvariant="normal">≠</mo><mn>𝟎</mn></mrow></math>,</span></p>
+<table id="S3.Ex33" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex33.m1" class="ltx_Math" alttext="\lambda_{\min}(\mathbf{A})\leq R_{\mathbf{A}}(\mathbf{x})\leq\lambda_{\max}(%
+\mathbf{A})" display="block"><mrow><mrow><msub><mi>λ</mi><mi>min</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><msub><mi>λ</mi><mi>max</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmtheorem3.p1.2" class="ltx_p"><span id="Thmtheorem3.p1.2.1" class="ltx_text ltx_font_italic">with equality if and only if <math id="Thmtheorem3.p1.2.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is a corresponding eigenvector.</span></p>
+</div>
+</div>
+</section>
+</section>
+<section id="S3.SS11" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.11 </span>Positive (semi-)definite matrices</h3>
+
+<div id="S3.SS11.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS11.p1.5" class="ltx_p">A symmetric matrix <math id="S3.SS11.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is <span id="S3.SS11.p1.5.1" class="ltx_text ltx_font_bold">positive semi-definite</span> if for all <math id="S3.SS11.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math>, <math id="S3.SS11.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}\geq 0" display="inline"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>≥</mo><mn>0</mn></mrow></math>.
+Sometimes people write <math id="S3.SS11.p1.4.m4" class="ltx_Math" alttext="\mathbf{A}\succeq 0" display="inline"><mrow><mi>𝐀</mi><mo>⪰</mo><mn>0</mn></mrow></math> to indicate that <math id="S3.SS11.p1.5.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive semi-definite.</p>
+</div>
+<div id="S3.SS11.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS11.p2.5" class="ltx_p">A symmetric matrix <math id="S3.SS11.p2.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is <span id="S3.SS11.p2.5.1" class="ltx_text ltx_font_bold">positive definite</span> if for all nonzero <math id="S3.SS11.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math>, <math id="S3.SS11.p2.3.m3" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}&gt;0" display="inline"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>&gt;</mo><mn>0</mn></mrow></math>.
+Sometimes people write <math id="S3.SS11.p2.4.m4" class="ltx_Math" alttext="\mathbf{A}\succ 0" display="inline"><mrow><mi>𝐀</mi><mo>≻</mo><mn>0</mn></mrow></math> to indicate that <math id="S3.SS11.p2.5.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive definite.
+Note that positive definiteness is a strictly stronger property than positive semi-definiteness, in the sense that every positive definite matrix is positive semi-definite but not vice-versa.</p>
+</div>
+<div id="S3.SS11.p3" class="ltx_para">
+<p id="S3.SS11.p3.1" class="ltx_p">These properties are related to eigenvalues in the following way.</p>
+</div>
+<div id="Thmproposition3" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition3.1.1.1" class="ltx_text ltx_font_bold">Proposition 3</span></span><span id="Thmproposition3.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition3.p1" class="ltx_para">
+<p id="Thmproposition3.p1.1" class="ltx_p"><span id="Thmproposition3.p1.1.1" class="ltx_text ltx_font_italic">A symmetric matrix is positive semi-definite if and only if all of its eigenvalues are nonnegative, and positive definite if and only if all of its eigenvalues are positive.</span></p>
+</div>
+</div>
+<div id="S3.SS11.2" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS11.1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS11.1.p1.4" class="ltx_p">Suppose <math id="S3.SS11.1.p1.1.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> is positive semi-definite, and let <math id="S3.SS11.1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> be an eigenvector of <math id="S3.SS11.1.p1.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> with eigenvalue <math id="S3.SS11.1.p1.4.m4" class="ltx_Math" alttext="\lambda" display="inline"><mi>λ</mi></math>.
+Then</p>
+<table id="S3.Ex34" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex34.m1" class="ltx_Math" alttext="0\leq\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=\mathbf{x}^{\!\top\!}(\lambda%
+\mathbf{x})=\lambda\mathbf{x}^{\!\top\!}\mathbf{x}=\lambda\|\mathbf{x}\|_{2}^{2}" display="block"><mrow><mn>0</mn><mo>≤</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>λ</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>λ</mi><mo>⁢</mo><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mi>λ</mi><mo>⁢</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.1.p1.10" class="ltx_p">Since <math id="S3.SS11.1.p1.5.m1" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mn>𝟎</mn></mrow></math> (by the assumption that it is an eigenvector), we have <math id="S3.SS11.1.p1.6.m2" class="ltx_Math" alttext="\|\mathbf{x}\|_{2}^{2}&gt;0" display="inline"><mrow><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup><mo>&gt;</mo><mn>0</mn></mrow></math>, so we can divide both sides by <math id="S3.SS11.1.p1.7.m3" class="ltx_Math" alttext="\|\mathbf{x}\|_{2}^{2}" display="inline"><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></math> to arrive at <math id="S3.SS11.1.p1.8.m4" class="ltx_Math" alttext="\lambda\geq 0" display="inline"><mrow><mi>λ</mi><mo>≥</mo><mn>0</mn></mrow></math>.
+If <math id="S3.SS11.1.p1.9.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive definite, the inequality above holds strictly, so <math id="S3.SS11.1.p1.10.m6" class="ltx_Math" alttext="\lambda&gt;0" display="inline"><mrow><mi>λ</mi><mo>&gt;</mo><mn>0</mn></mrow></math>.
+This proves one direction.</p>
+</div>
+<div id="S3.SS11.2.p2" class="ltx_para">
+<p id="S3.SS11.2.p2.2" class="ltx_p">To simplify the proof of the other direction, we will use the machinery of Rayleigh quotients.
+Suppose that <math id="S3.SS11.2.p2.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is symmetric and all its eigenvalues are nonnegative.
+Then for all <math id="S3.SS11.2.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mn>𝟎</mn></mrow></math>,</p>
+<table id="S3.Ex35" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex35.m1" class="ltx_Math" alttext="0\leq\lambda_{\min}(\mathbf{A})\leq R_{\mathbf{A}}(\mathbf{x})" display="block"><mrow><mn>0</mn><mo>≤</mo><mrow><msub><mi>λ</mi><mi>min</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.2.p2.8" class="ltx_p">Since <math id="S3.SS11.2.p2.3.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></math> matches <math id="S3.SS11.2.p2.4.m2" class="ltx_Math" alttext="R_{\mathbf{A}}(\mathbf{x})" display="inline"><mrow><msub><mi>R</mi><mi>𝐀</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math> in sign, we conclude that <math id="S3.SS11.2.p2.5.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive semi-definite.
+If the eigenvalues of <math id="S3.SS11.2.p2.6.m4" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> are all strictly positive, then <math id="S3.SS11.2.p2.7.m5" class="ltx_Math" alttext="0&lt;\lambda_{\min}(\mathbf{A})" display="inline"><mrow><mn>0</mn><mo>&lt;</mo><mrow><msub><mi>λ</mi><mi>min</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>, whence it follows that <math id="S3.SS11.2.p2.8.m6" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive definite.
+∎</p>
+</div>
+</div>
+<div id="S3.SS11.p4" class="ltx_para">
+<p id="S3.SS11.p4.1" class="ltx_p">As an example of how these matrices arise, consider</p>
+</div>
+<div id="Thmproposition4" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition4.1.1.1" class="ltx_text ltx_font_bold">Proposition 4</span></span><span id="Thmproposition4.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition4.p1" class="ltx_para">
+<p id="Thmproposition4.p1.4" class="ltx_p"><span id="Thmproposition4.p1.4.4" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition4.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{m\times n}" display="inline"><mrow><mi>𝐀</mi><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo mathvariant="normal">×</mo><mi>n</mi></mrow></msup></mrow></math>.
+Then <math id="Thmproposition4.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" mathvariant="normal" rspace="0.8pt">⊤</mo></msup><mo mathvariant="italic">⁢</mo><mi>𝐀</mi></mrow></math> is positive semi-definite.
+If <math id="Thmproposition4.p1.3.3.m3" class="ltx_Math" alttext="\operatorname*{null}(\mathbf{A})=\{\mathbf{0}\}" display="inline"><mrow><mrow><mo mathvariant="normal">null</mo><mo mathvariant="italic">⁡</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>𝐀</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">=</mo><mrow><mo mathvariant="normal" stretchy="false">{</mo><mn>𝟎</mn><mo mathvariant="normal" stretchy="false">}</mo></mrow></mrow></math>, then <math id="Thmproposition4.p1.4.4.m4" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" mathvariant="normal" rspace="0.8pt">⊤</mo></msup><mo mathvariant="italic">⁢</mo><mi>𝐀</mi></mrow></math> is positive definite.</span></p>
+</div>
+</div>
+<div id="S3.SS11.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS11.3.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS11.3.p1.1" class="ltx_p">For any <math id="S3.SS11.3.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math>,</p>
+<table id="S3.Ex36" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex36.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}(\mathbf{A}^{\!\top\!}\mathbf{A})\mathbf{x}=(\mathbf{A}%
+\mathbf{x})^{\!\top\!}(\mathbf{A}\mathbf{x})=\|\mathbf{A}\mathbf{x}\|_{2}^{2}\geq
+0" display="block"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><msup><mrow><mo stretchy="false">(</mo><mi>𝐀𝐱</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐀𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msubsup><mrow><mo>∥</mo><mi>𝐀𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup><mo>≥</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.3.p1.2" class="ltx_p">so <math id="S3.SS11.3.p1.2.m1" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math> is positive semi-definite.</p>
+</div>
+<div id="S3.SS11.4.p2" class="ltx_para">
+<p id="S3.SS11.4.p2.9" class="ltx_p">Note that <math id="S3.SS11.4.p2.1.m1" class="ltx_Math" alttext="\|\mathbf{A}\mathbf{x}\|_{2}^{2}=0" display="inline"><mrow><msubsup><mrow><mo>∥</mo><mi>𝐀𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup><mo>=</mo><mn>0</mn></mrow></math> implies <math id="S3.SS11.4.p2.2.m2" class="ltx_Math" alttext="\|\mathbf{A}\mathbf{x}\|_{2}=0" display="inline"><mrow><msub><mrow><mo>∥</mo><mi>𝐀𝐱</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>0</mn></mrow></math>, which in turn implies <math id="S3.SS11.4.p2.3.m3" class="ltx_Math" alttext="\mathbf{A}\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐀𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math> (recall that this is a property of norms).
+If <math id="S3.SS11.4.p2.4.m4" class="ltx_Math" alttext="\operatorname*{null}(\mathbf{A})=\{\mathbf{0}\}" display="inline"><mrow><mrow><mo>null</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>𝐀</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo stretchy="false">{</mo><mn>𝟎</mn><mo stretchy="false">}</mo></mrow></mrow></math>, <math id="S3.SS11.4.p2.5.m5" class="ltx_Math" alttext="\mathbf{A}\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐀𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math> implies <math id="S3.SS11.4.p2.6.m6" class="ltx_Math" alttext="\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math>, so <math id="S3.SS11.4.p2.7.m7" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}(\mathbf{A}^{\!\top\!}\mathbf{A})\mathbf{x}=0" display="inline"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mn>0</mn></mrow></math> if and only if <math id="S3.SS11.4.p2.8.m8" class="ltx_Math" alttext="\mathbf{x}=\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>=</mo><mn>𝟎</mn></mrow></math>, and thus <math id="S3.SS11.4.p2.9.m9" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math> is positive definite.
+∎</p>
+</div>
+</div>
+<div id="S3.SS11.p5" class="ltx_para">
+<p id="S3.SS11.p5.1" class="ltx_p">Positive definite matrices are invertible (since their eigenvalues are nonzero), whereas positive semi-definite matrices might not be.
+However, if you already have a positive semi-definite matrix, it is possible to perturb its diagonal slightly to produce a positive definite matrix.</p>
+</div>
+<div id="Thmproposition5" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition5.1.1.1" class="ltx_text ltx_font_bold">Proposition 5</span></span><span id="Thmproposition5.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition5.p1" class="ltx_para">
+<p id="Thmproposition5.p1.3" class="ltx_p"><span id="Thmproposition5.p1.3.3" class="ltx_text ltx_font_italic">If <math id="Thmproposition5.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive semi-definite and <math id="Thmproposition5.p1.2.2.m2" class="ltx_Math" alttext="\epsilon&gt;0" display="inline"><mrow><mi>ϵ</mi><mo mathvariant="normal">&gt;</mo><mn mathvariant="normal">0</mn></mrow></math>, then <math id="Thmproposition5.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{A}+\epsilon\mathbf{I}" display="inline"><mrow><mi>𝐀</mi><mo mathvariant="normal">+</mo><mrow><mi>ϵ</mi><mo mathvariant="italic">⁢</mo><mi>𝐈</mi></mrow></mrow></math> is positive definite.</span></p>
+</div>
+</div>
+<div id="S3.SS11.5" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS11.5.p1" class="ltx_para">
+<p id="S3.SS11.5.p1.3" class="ltx_p">Assuming <math id="S3.SS11.5.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive semi-definite and <math id="S3.SS11.5.p1.2.m2" class="ltx_Math" alttext="\epsilon&gt;0" display="inline"><mrow><mi>ϵ</mi><mo>&gt;</mo><mn>0</mn></mrow></math>, we have for any <math id="S3.SS11.5.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{0}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mn>𝟎</mn></mrow></math> that</p>
+<table id="S3.Ex37" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex37.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}(\mathbf{A}+\epsilon\mathbf{I})\mathbf{x}=\mathbf{x}^{\!%
+\top\!}\mathbf{A}\mathbf{x}+\epsilon\mathbf{x}^{\!\top\!}\mathbf{I}\mathbf{x}=%
+\underbrace{\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}}_{\geq 0}+\underbrace{%
+\epsilon\|\mathbf{x}\|_{2}^{2}}_{&gt;0}&gt;0" display="block"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀</mi><mo>+</mo><mrow><mi>ϵ</mi><mo>⁢</mo><mi>𝐈</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>+</mo><mrow><mi>ϵ</mi><mo>⁢</mo><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐈𝐱</mi></mrow></mrow><mo>=</mo><mrow><munder><munder accentunder="true"><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" movablelimits="false" rspace="0.8pt">⊤</mo></msup><mo movablelimits="false">⁢</mo><mi>𝐀𝐱</mi></mrow><mo movablelimits="false">⏟</mo></munder><mrow><mi></mi><mo>≥</mo><mn>0</mn></mrow></munder><mo>+</mo><munder><munder accentunder="true"><mrow><mi>ϵ</mi><mo movablelimits="false">⁢</mo><msubsup><mrow><mo movablelimits="false">∥</mo><mi>𝐱</mi><mo movablelimits="false">∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow><mo movablelimits="false">⏟</mo></munder><mrow><mi></mi><mo>&gt;</mo><mn>0</mn></mrow></munder></mrow><mo>&gt;</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.5.p1.4" class="ltx_p">as claimed.
+∎</p>
+</div>
+</div>
+<div id="S3.SS11.p6" class="ltx_para ltx_noindent">
+<p id="S3.SS11.p6.3" class="ltx_p">An obvious but frequently useful consequence of the two propositions we have just shown is that <math id="S3.SS11.p6.1.m1" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}+\epsilon\mathbf{I}" display="inline"><mrow><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow><mo>+</mo><mrow><mi>ϵ</mi><mo>⁢</mo><mi>𝐈</mi></mrow></mrow></math> is positive definite (and in particular, invertible) for <span id="S3.SS11.p6.3.1" class="ltx_text ltx_font_italic">any</span> matrix <math id="S3.SS11.p6.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and any <math id="S3.SS11.p6.3.m3" class="ltx_Math" alttext="\epsilon&gt;0" display="inline"><mrow><mi>ϵ</mi><mo>&gt;</mo><mn>0</mn></mrow></math>.</p>
+</div>
+<section id="S3.SS11.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.11.1 </span>The geometry of positive definite quadratic forms</h4>
+
+<div id="S3.SS11.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS11.SSS1.p1.3" class="ltx_p">A useful way to understand quadratic forms is by the geometry of their level sets.
+A <span id="S3.SS11.SSS1.p1.3.1" class="ltx_text ltx_font_bold">level set</span> or <span id="S3.SS11.SSS1.p1.3.2" class="ltx_text ltx_font_bold">isocontour</span> of a function is the set of all inputs such that the function applied to those inputs yields a given output.
+Mathematically, the <math id="S3.SS11.SSS1.p1.1.m1" class="ltx_Math" alttext="c" display="inline"><mi>c</mi></math>-isocontour of <math id="S3.SS11.SSS1.p1.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is <math id="S3.SS11.SSS1.p1.3.m3" class="ltx_Math" alttext="\{\mathbf{x}\in\operatorname*{dom}f\mathrel{\mathop{:}}f(\mathbf{x})=c\}" display="inline"><mrow><mo stretchy="false">{</mo><mrow><mi>𝐱</mi><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow><mo>:</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mi>c</mi></mrow><mo stretchy="false">}</mo></mrow></math>.</p>
+</div>
+<div id="S3.SS11.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS11.SSS1.p2.13" class="ltx_p">Let us consider the special case <math id="S3.SS11.SSS1.p2.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></mrow></math> where <math id="S3.SS11.SSS1.p2.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is a positive definite matrix.
+Since <math id="S3.SS11.SSS1.p2.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is positive definite, it has a unique matrix square root <math id="S3.SS11.SSS1.p2.4.m4" class="ltx_Math" alttext="\mathbf{A}^{\frac{1}{2}}=\mathbf{Q}\mathbf{\Lambda}^{\frac{1}{2}}\mathbf{Q}^{%
+\!\top\!}" display="inline"><mrow><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><msup><mi>𝚲</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math>, where <math id="S3.SS11.SSS1.p2.5.m5" class="ltx_Math" alttext="\mathbf{Q}\mathbf{\Lambda}\mathbf{Q}^{\!\top\!}" display="inline"><mrow><mi>𝐐</mi><mo>⁢</mo><mi>𝚲</mi><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></math> is the eigendecomposition of <math id="S3.SS11.SSS1.p2.6.m6" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and <math id="S3.SS11.SSS1.p2.7.m7" class="ltx_Math" alttext="\mathbf{\Lambda}^{\frac{1}{2}}=\operatorname*{diag}(\sqrt{\lambda_{1}},\dots%
+\sqrt{\lambda_{n}})" display="inline"><mrow><msup><mi>𝚲</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>=</mo><mrow><mo>diag</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msqrt><msub><mi>λ</mi><mn>1</mn></msub></msqrt><mo>,</mo><mrow><mi mathvariant="normal">…</mi><mo>⁢</mo><msqrt><msub><mi>λ</mi><mi>n</mi></msub></msqrt></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+It is easy to see that this matrix <math id="S3.SS11.SSS1.p2.8.m8" class="ltx_Math" alttext="\mathbf{A}^{\frac{1}{2}}" display="inline"><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup></math> is positive definite (consider its eigenvalues) and satisfies <math id="S3.SS11.SSS1.p2.9.m9" class="ltx_Math" alttext="\mathbf{A}^{\frac{1}{2}}\mathbf{A}^{\frac{1}{2}}=\mathbf{A}" display="inline"><mrow><mrow><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup></mrow><mo>=</mo><mi>𝐀</mi></mrow></math>.
+Fixing a value <math id="S3.SS11.SSS1.p2.10.m10" class="ltx_Math" alttext="c\geq 0" display="inline"><mrow><mi>c</mi><mo>≥</mo><mn>0</mn></mrow></math>, the <math id="S3.SS11.SSS1.p2.11.m11" class="ltx_Math" alttext="c" display="inline"><mi>c</mi></math>-isocontour of <math id="S3.SS11.SSS1.p2.12.m12" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is the set of <math id="S3.SS11.SSS1.p2.13.m13" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math> such that</p>
+<table id="S3.Ex38" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex38.m1" class="ltx_Math" alttext="c=\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=\mathbf{x}^{\!\top\!}\mathbf{A}^{%
+\frac{1}{2}}\mathbf{A}^{\frac{1}{2}}\mathbf{x}=\|\mathbf{A}^{\frac{1}{2}}%
+\mathbf{x}\|_{2}^{2}" display="block"><mrow><mi>c</mi><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><msubsup><mrow><mo>∥</mo><mrow><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.SSS1.p2.22" class="ltx_p">where we have used the symmetry of <math id="S3.SS11.SSS1.p2.14.m1" class="ltx_Math" alttext="\mathbf{A}^{\frac{1}{2}}" display="inline"><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup></math>.
+Making the change of variable <math id="S3.SS11.SSS1.p2.15.m2" class="ltx_Math" alttext="\mathbf{z}=\mathbf{A}^{\frac{1}{2}}\mathbf{x}" display="inline"><mrow><mi>𝐳</mi><mo>=</mo><mrow><msup><mi>𝐀</mi><mfrac><mn>1</mn><mn>2</mn></mfrac></msup><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math>, we have the condition <math id="S3.SS11.SSS1.p2.16.m3" class="ltx_Math" alttext="\|\mathbf{z}\|_{2}=\sqrt{c}" display="inline"><mrow><msub><mrow><mo>∥</mo><mi>𝐳</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><msqrt><mi>c</mi></msqrt></mrow></math>.
+That is, the values <math id="S3.SS11.SSS1.p2.17.m4" class="ltx_Math" alttext="\mathbf{z}" display="inline"><mi>𝐳</mi></math> lie on a sphere of radius <math id="S3.SS11.SSS1.p2.18.m5" class="ltx_Math" alttext="\sqrt{c}" display="inline"><msqrt><mi>c</mi></msqrt></math>.
+These can be parameterized as <math id="S3.SS11.SSS1.p2.19.m6" class="ltx_Math" alttext="\mathbf{z}=\sqrt{c}\hat{\mathbf{z}}" display="inline"><mrow><mi>𝐳</mi><mo>=</mo><mrow><msqrt><mi>c</mi></msqrt><mo>⁢</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">^</mo></mover></mrow></mrow></math> where <math id="S3.SS11.SSS1.p2.20.m7" class="ltx_Math" alttext="\hat{\mathbf{z}}" display="inline"><mover accent="true"><mi>𝐳</mi><mo stretchy="false">^</mo></mover></math> has <math id="S3.SS11.SSS1.p2.21.m8" class="ltx_Math" alttext="\|\hat{\mathbf{z}}\|_{2}=1" display="inline"><mrow><msub><mrow><mo>∥</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">^</mo></mover><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></math>.
+Then since <math id="S3.SS11.SSS1.p2.22.m9" class="ltx_Math" alttext="\mathbf{A}^{-\frac{1}{2}}=\mathbf{Q}\mathbf{\Lambda}^{-\frac{1}{2}}\mathbf{Q}^%
+{\!\top\!}" display="inline"><mrow><msup><mi>𝐀</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><msup><mi>𝚲</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math>, we have</p>
+<table id="S3.Ex39" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex39.m1" class="ltx_Math" alttext="\mathbf{x}=\mathbf{A}^{-\frac{1}{2}}\mathbf{z}=\mathbf{Q}\mathbf{\Lambda}^{-%
+\frac{1}{2}}\mathbf{Q}^{\!\top\!}\sqrt{c}\hat{\mathbf{z}}=\sqrt{c}\mathbf{Q}%
+\mathbf{\Lambda}^{-\frac{1}{2}}\tilde{\mathbf{z}}" display="block"><mrow><mi>𝐱</mi><mo>=</mo><mrow><msup><mi>𝐀</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><mi>𝐳</mi></mrow><mo>=</mo><mrow><mi>𝐐</mi><mo>⁢</mo><msup><mi>𝚲</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msqrt><mi>c</mi></msqrt><mo>⁢</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">^</mo></mover></mrow><mo>=</mo><mrow><msqrt><mi>c</mi></msqrt><mo>⁢</mo><mi>𝐐</mi><mo>⁢</mo><msup><mi>𝚲</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.SSS1.p2.28" class="ltx_p">where <math id="S3.SS11.SSS1.p2.23.m1" class="ltx_Math" alttext="\tilde{\mathbf{z}}=\mathbf{Q}^{\!\top\!}\hat{\mathbf{z}}" display="inline"><mrow><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover><mo>=</mo><mrow><msup><mi>𝐐</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">^</mo></mover></mrow></mrow></math> also satisfies <math id="S3.SS11.SSS1.p2.24.m2" class="ltx_Math" alttext="\|\tilde{\mathbf{z}}\|_{2}=1" display="inline"><mrow><msub><mrow><mo>∥</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow></math> since <math id="S3.SS11.SSS1.p2.25.m3" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math> is orthogonal.
+Using this parameterization, we see that the solution set <math id="S3.SS11.SSS1.p2.26.m4" class="ltx_Math" alttext="\{\mathbf{x}\in\mathbb{R}^{n}\mathrel{\mathop{:}}f(\mathbf{x})=c\}" display="inline"><mrow><mo stretchy="false">{</mo><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo>:</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mi>c</mi></mrow><mo stretchy="false">}</mo></mrow></math> is the image of the unit sphere <math id="S3.SS11.SSS1.p2.27.m5" class="ltx_Math" alttext="\{\tilde{\mathbf{z}}\in\mathbb{R}^{n}\mathrel{\mathop{:}}\|\tilde{\mathbf{z}}%
+\|_{2}=1\}" display="inline"><mrow><mo stretchy="false">{</mo><mrow><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo>:</mo><msub><mrow><mo>∥</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mn>1</mn></mrow><mo stretchy="false">}</mo></mrow></math> under the invertible linear map <math id="S3.SS11.SSS1.p2.28.m6" class="ltx_Math" alttext="\mathbf{x}=\sqrt{c}\mathbf{Q}\mathbf{\Lambda}^{-\frac{1}{2}}\tilde{\mathbf{z}}" display="inline"><mrow><mi>𝐱</mi><mo>=</mo><mrow><msqrt><mi>c</mi></msqrt><mo>⁢</mo><mi>𝐐</mi><mo>⁢</mo><msup><mi>𝚲</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐳</mi><mo stretchy="false">~</mo></mover></mrow></mrow></math>.</p>
+</div>
+<div id="S3.SS11.SSS1.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS11.SSS1.p3.5" class="ltx_p">What we have gained with all these manipulations is a clear algebraic understanding of the <math id="S3.SS11.SSS1.p3.1.m1" class="ltx_Math" alttext="c" display="inline"><mi>c</mi></math>-isocontour of <math id="S3.SS11.SSS1.p3.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in terms of a sequence of linear transformations applied to a well-understood set.
+We begin with the unit sphere, then scale every axis <math id="S3.SS11.SSS1.p3.3.m3" class="ltx_Math" alttext="i" display="inline"><mi>i</mi></math> by <math id="S3.SS11.SSS1.p3.4.m4" class="ltx_Math" alttext="\lambda_{i}^{-\frac{1}{2}}" display="inline"><msubsup><mi>λ</mi><mi>i</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msubsup></math>, resulting in an axis-aligned ellipsoid.
+Observe that the axis lengths of the ellipsoid are proportional to the inverse square roots of the eigenvalues of <math id="S3.SS11.SSS1.p3.5.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>.
+Hence larger eigenvalues correspond to shorter axis lengths, and vice-versa.</p>
+</div>
+<div id="S3.SS11.SSS1.p4" class="ltx_para ltx_noindent">
+<p id="S3.SS11.SSS1.p4.6" class="ltx_p">Then this axis-aligned ellipsoid undergoes a rigid transformation (i.e. one that preserves length and angles, such as a rotation/reflection) given by <math id="S3.SS11.SSS1.p4.1.m1" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math>.
+The result of this transformation is that the axes of the ellipse are no longer along the coordinate axes in general, but rather along the directions given by the corresponding eigenvectors.
+To see this, consider the unit vector <math id="S3.SS11.SSS1.p4.2.m2" class="ltx_Math" alttext="\mathbf{e}_{i}\in\mathbb{R}^{n}" display="inline"><mrow><msub><mi>𝐞</mi><mi>i</mi></msub><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math> that has <math id="S3.SS11.SSS1.p4.3.m3" class="ltx_Math" alttext="[\mathbf{e}_{i}]_{j}=\delta_{ij}" display="inline"><mrow><msub><mrow><mo stretchy="false">[</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo stretchy="false">]</mo></mrow><mi>j</mi></msub><mo>=</mo><msub><mi>δ</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub></mrow></math>.
+In the pre-transformed space, this vector points along the axis with length proportional to <math id="S3.SS11.SSS1.p4.4.m4" class="ltx_Math" alttext="\lambda_{i}^{-\frac{1}{2}}" display="inline"><msubsup><mi>λ</mi><mi>i</mi><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msubsup></math>.
+But after applying the rigid transformation <math id="S3.SS11.SSS1.p4.5.m5" class="ltx_Math" alttext="\mathbf{Q}" display="inline"><mi>𝐐</mi></math>, the resulting vector points in the direction of the corresponding eigenvector <math id="S3.SS11.SSS1.p4.6.m6" class="ltx_Math" alttext="\mathbf{q}_{i}" display="inline"><msub><mi>𝐪</mi><mi>i</mi></msub></math>, since</p>
+<table id="S3.Ex40" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex40.m1" class="ltx_Math" alttext="\mathbf{Q}\mathbf{e}_{i}=\sum_{j=1}^{n}[\mathbf{e}_{i}]_{j}\mathbf{q}_{j}=%
+\mathbf{q}_{i}" display="block"><mrow><msub><mi>𝐐𝐞</mi><mi>i</mi></msub><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>j</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mrow><mo stretchy="false">[</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo stretchy="false">]</mo></mrow><mi>j</mi></msub><mo>⁢</mo><msub><mi>𝐪</mi><mi>j</mi></msub></mrow></mrow><mo>=</mo><msub><mi>𝐪</mi><mi>i</mi></msub></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS11.SSS1.p4.7" class="ltx_p">where we have used the matrix-vector product identity from earlier.</p>
+</div>
+<div id="S3.SS11.SSS1.p5" class="ltx_para ltx_noindent">
+<p id="S3.SS11.SSS1.p5.2" class="ltx_p">In summary: the isocontours of <math id="S3.SS11.SSS1.p5.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></mrow></math> are ellipsoids such that the axes point in the directions of the eigenvectors of <math id="S3.SS11.SSS1.p5.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>, and the radii of these axes are proportional to the inverse square roots of the corresponding eigenvalues.</p>
+</div>
+</section>
+</section>
+<section id="S3.SS12" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.12 </span>Singular value decomposition</h3>
+
+<div id="S3.SS12.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS12.p1.1" class="ltx_p">Singular value decomposition (SVD) is a widely applicable tool in linear algebra.
+Its strength stems partially from the fact that <span id="S3.SS12.p1.1.1" class="ltx_text ltx_font_italic">every matrix</span> <math id="S3.SS12.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{m\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> has an SVD (even non-square matrices)!
+The decomposition goes as follows:</p>
+<table id="S3.Ex41" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex41.m1" class="ltx_Math" alttext="\mathbf{A}=\mathbf{U}\mathbf{\Sigma}\mathbf{V}^{\!\top\!}" display="block"><mrow><mi>𝐀</mi><mo>=</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS12.p1.6" class="ltx_p">where <math id="S3.SS12.p1.2.m1" class="ltx_Math" alttext="\mathbf{U}\in\mathbb{R}^{m\times m}" display="inline"><mrow><mi>𝐔</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo>×</mo><mi>m</mi></mrow></msup></mrow></math> and <math id="S3.SS12.p1.3.m2" class="ltx_Math" alttext="\mathbf{V}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐕</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> are orthogonal matrices and <math id="S3.SS12.p1.4.m3" class="ltx_Math" alttext="\mathbf{\Sigma}\in\mathbb{R}^{m\times n}" display="inline"><mrow><mi>𝚺</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> is a diagonal matrix with the <span id="S3.SS12.p1.6.1" class="ltx_text ltx_font_bold">singular values</span> of <math id="S3.SS12.p1.5.m4" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> (denoted <math id="S3.SS12.p1.6.m5" class="ltx_Math" alttext="\sigma_{i}" display="inline"><msub><mi>σ</mi><mi>i</mi></msub></math>) on its diagonal.</p>
+</div>
+<div id="S3.SS12.p2" class="ltx_para ltx_noindent">
+<p id="S3.SS12.p2.4" class="ltx_p">By convention, the singular values are given in non-increasing order, i.e.</p>
+<table id="S3.Ex42" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex42.m1" class="ltx_Math" alttext="\sigma_{1}\geq\sigma_{2}\geq\dots\geq\sigma_{\min(m,n)}\geq 0" display="block"><mrow><msub><mi>σ</mi><mn>1</mn></msub><mo>≥</mo><msub><mi>σ</mi><mn>2</mn></msub><mo>≥</mo><mi mathvariant="normal">⋯</mi><mo>≥</mo><msub><mi>σ</mi><mrow><mi>min</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>m</mi><mo>,</mo><mi>n</mi><mo stretchy="false">)</mo></mrow></mrow></msub><mo>≥</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS12.p2.3" class="ltx_p">Only the first <math id="S3.SS12.p2.1.m1" class="ltx_Math" alttext="r" display="inline"><mi>r</mi></math> singular values are nonzero, where <math id="S3.SS12.p2.2.m2" class="ltx_Math" alttext="r" display="inline"><mi>r</mi></math> is the rank of <math id="S3.SS12.p2.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>.</p>
+</div>
+<div id="S3.SS12.p3" class="ltx_para ltx_noindent">
+<p id="S3.SS12.p3.2" class="ltx_p">Observe that the SVD factors provide eigendecompositions for <math id="S3.SS12.p3.1.m1" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math> and <math id="S3.SS12.p3.2.m2" class="ltx_Math" alttext="\mathbf{A}\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>:</p>
+<table id="Sx1.EGx2" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S3.Ex43"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex43.m1" class="ltx_Math" alttext="\displaystyle\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex43.m2" class="ltx_Math" alttext="\displaystyle=(\mathbf{U}\mathbf{\Sigma}\mathbf{V}^{\!\top\!})^{\!\top\!}%
+\mathbf{U}\mathbf{\Sigma}\mathbf{V}^{\!\top\!}=\mathbf{V}\mathbf{\Sigma}^{\!%
+\top\!}\mathbf{U}^{\!\top\!}\mathbf{U}\mathbf{\Sigma}\mathbf{V}^{\!\top\!}=%
+\mathbf{V}\mathbf{\Sigma}^{\!\top\!}\mathbf{\Sigma}\mathbf{V}^{\!\top\!}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo>=</mo><mrow><mi>𝐕</mi><mo>⁢</mo><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐔</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo>=</mo><mrow><mi>𝐕</mi><mo>⁢</mo><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S3.Ex44"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S3.Ex44.m1" class="ltx_Math" alttext="\displaystyle\mathbf{A}\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S3.Ex44.m2" class="ltx_Math" alttext="\displaystyle=\mathbf{U}\mathbf{\Sigma}\mathbf{V}^{\!\top\!}(\mathbf{U}\mathbf%
+{\Sigma}\mathbf{V}^{\!\top\!})^{\!\top\!}=\mathbf{U}\mathbf{\Sigma}\mathbf{V}^%
+{\!\top\!}\mathbf{V}\mathbf{\Sigma}^{\!\top\!}\mathbf{U}^{\!\top\!}=\mathbf{U}%
+\mathbf{\Sigma}\mathbf{\Sigma}^{\!\top\!}\mathbf{U}^{\!\top\!}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo>=</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝐕</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐕</mi><mo>⁢</mo><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐔</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo>=</mo><mrow><mi>𝐔</mi><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝐔</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S3.SS12.p3.8" class="ltx_p">It follows immediately that the columns of <math id="S3.SS12.p3.3.m1" class="ltx_Math" alttext="\mathbf{V}" display="inline"><mi>𝐕</mi></math> (the <span id="S3.SS12.p3.8.1" class="ltx_text ltx_font_bold">right-singular vectors</span> of <math id="S3.SS12.p3.4.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>) are eigenvectors of <math id="S3.SS12.p3.5.m3" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math>, and the columns of <math id="S3.SS12.p3.6.m4" class="ltx_Math" alttext="\mathbf{U}" display="inline"><mi>𝐔</mi></math> (the <span id="S3.SS12.p3.8.2" class="ltx_text ltx_font_bold">left-singular vectors</span> of <math id="S3.SS12.p3.7.m5" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>) are eigenvectors of <math id="S3.SS12.p3.8.m6" class="ltx_Math" alttext="\mathbf{A}\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>.</p>
+</div>
+<div id="S3.SS12.p4" class="ltx_para ltx_noindent">
+<p id="S3.SS12.p4.6" class="ltx_p">The matrices <math id="S3.SS12.p4.1.m1" class="ltx_Math" alttext="\mathbf{\Sigma}^{\!\top\!}\mathbf{\Sigma}" display="inline"><mrow><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝚺</mi></mrow></math> and <math id="S3.SS12.p4.2.m2" class="ltx_Math" alttext="\mathbf{\Sigma}\mathbf{\Sigma}^{\!\top\!}" display="inline"><mrow><mi>𝚺</mi><mo>⁢</mo><msup><mi>𝚺</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></math> are not necessarily the same size, but both are diagonal with the squared singular values <math id="S3.SS12.p4.3.m3" class="ltx_Math" alttext="\sigma_{i}^{2}" display="inline"><msubsup><mi>σ</mi><mi>i</mi><mn>2</mn></msubsup></math> on the diagonal (plus possibly some zeros).
+Thus the singular values of <math id="S3.SS12.p4.4.m4" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> are the square roots of the eigenvalues of <math id="S3.SS12.p4.5.m5" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math> (or equivalently, of <math id="S3.SS12.p4.6.m6" class="ltx_Math" alttext="\mathbf{A}\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>)<span id="footnote5" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">5</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">5</sup><span class="ltx_tag ltx_tag_note">5</span>
+Recall that <math id="footnote5.m1" class="ltx_Math" alttext="\mathbf{A}^{\!\top\!}\mathbf{A}" display="inline"><mrow><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀</mi></mrow></math> and <math id="footnote5.m2" class="ltx_Math" alttext="\mathbf{A}\mathbf{A}^{\!\top\!}" display="inline"><msup><mi>𝐀𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math> are positive semi-definite, so their eigenvalues are nonnegative, and thus taking square roots is always well-defined.
+</span></span></span>.</p>
+</div>
+</section>
+<section id="S3.SS13" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">3.13 </span>Some useful matrix identities</h3>
+
+<section id="S3.SS13.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.13.1 </span>Matrix-vector product as linear combination of matrix columns</h4>
+
+<div id="Thmproposition6" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition6.1.1.1" class="ltx_text ltx_font_bold">Proposition 6</span></span><span id="Thmproposition6.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition6.p1" class="ltx_para">
+<p id="Thmproposition6.p1.3" class="ltx_p"><span id="Thmproposition6.p1.3.3" class="ltx_text ltx_font_italic">Let <math id="Thmproposition6.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐱</mi><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math> be a vector and <math id="Thmproposition6.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{m\times n}" display="inline"><mrow><mi>𝐀</mi><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mrow><mi>m</mi><mo mathvariant="normal">×</mo><mi>n</mi></mrow></msup></mrow></math> a matrix with columns <math id="Thmproposition6.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{a}_{1},\dots,\mathbf{a}_{n}" display="inline"><mrow><msub><mi>𝐚</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>𝐚</mi><mi>n</mi></msub></mrow></math>.
+Then</span></p>
+<table id="S3.Ex45" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex45.m1" class="ltx_Math" alttext="\mathbf{A}\mathbf{x}=\sum_{i=1}^{n}x_{i}\mathbf{a}_{i}" display="block"><mrow><mi>𝐀𝐱</mi><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>x</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>𝐚</mi><mi>i</mi></msub></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S3.SS13.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS13.SSS1.p1.1" class="ltx_p">This identity is extremely useful in understanding linear operators in terms of their matrices’ columns.
+The proof is very simple (consider each element of <math id="S3.SS13.SSS1.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\mathbf{x}" display="inline"><mi>𝐀𝐱</mi></math> individually and expand by definitions) but it is a good exercise to convince yourself.</p>
+</div>
+</section>
+<section id="S3.SS13.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.13.2 </span>Sum of outer products as matrix-matrix product</h4>
+
+<div id="S3.SS13.SSS2.p1" class="ltx_para">
+<p id="S3.SS13.SSS2.p1.4" class="ltx_p">An <span id="S3.SS13.SSS2.p1.4.1" class="ltx_text ltx_font_bold">outer product</span> is an expression of the form <math id="S3.SS13.SSS2.p1.1.m1" class="ltx_Math" alttext="\mathbf{a}\mathbf{b}^{\!\top\!}" display="inline"><msup><mi>𝐚𝐛</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>, where <math id="S3.SS13.SSS2.p1.2.m2" class="ltx_Math" alttext="\mathbf{a}\in\mathbb{R}^{m}" display="inline"><mrow><mi>𝐚</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>m</mi></msup></mrow></math> and <math id="S3.SS13.SSS2.p1.3.m3" class="ltx_Math" alttext="\mathbf{b}\in\mathbb{R}^{n}" display="inline"><mrow><mi>𝐛</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math>.
+By inspection it is not hard to see that such an expression yields an <math id="S3.SS13.SSS2.p1.4.m4" class="ltx_Math" alttext="m\times n" display="inline"><mrow><mi>m</mi><mo>×</mo><mi>n</mi></mrow></math> matrix such that</p>
+<table id="S3.Ex46" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex46.m1" class="ltx_Math" alttext="[\mathbf{a}\mathbf{b}^{\!\top\!}]_{ij}=a_{i}b_{j}" display="block"><mrow><msub><mrow><mo stretchy="false">[</mo><msup><mi>𝐚𝐛</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo stretchy="false">]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mrow><msub><mi>a</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>b</mi><mi>j</mi></msub></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS13.SSS2.p1.5" class="ltx_p">It is not immediately obvious, but the sum of outer products is actually equivalent to an appropriate matrix-matrix product!
+We formalize this statement as</p>
+</div>
+<div id="Thmproposition7" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition7.1.1.1" class="ltx_text ltx_font_bold">Proposition 7</span></span><span id="Thmproposition7.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition7.p1" class="ltx_para">
+<p id="Thmproposition7.p1.2" class="ltx_p"><span id="Thmproposition7.p1.2.2" class="ltx_text ltx_font_italic">Let <math id="Thmproposition7.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{a}_{1},\dots,\mathbf{a}_{k}\in\mathbb{R}^{m}" display="inline"><mrow><mrow><msub><mi>𝐚</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>𝐚</mi><mi>k</mi></msub></mrow><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mi>m</mi></msup></mrow></math> and <math id="Thmproposition7.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{b}_{1},\dots,\mathbf{b}_{k}\in\mathbb{R}^{n}" display="inline"><mrow><mrow><msub><mi>𝐛</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>𝐛</mi><mi>k</mi></msub></mrow><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mi>n</mi></msup></mrow></math>. Then</span></p>
+<table id="S3.Ex47" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex47.m1" class="ltx_Math" alttext="\sum_{\ell=1}^{k}\mathbf{a}_{\ell}\mathbf{b}_{\ell}^{\!\top\!}=\mathbf{A}%
+\mathbf{B}^{\!\top\!}" display="block"><mrow><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi mathvariant="normal">ℓ</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><mrow><msub><mi>𝐚</mi><mi mathvariant="normal">ℓ</mi></msub><mo>⁢</mo><msubsup><mi>𝐛</mi><mi mathvariant="normal">ℓ</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msubsup></mrow></mrow><mo>=</mo><msup><mi>𝐀𝐁</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmproposition7.p1.3" class="ltx_p"><span id="Thmproposition7.p1.3.1" class="ltx_text ltx_font_italic">where</span></p>
+<table id="S3.Ex48" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex48.m1" class="ltx_Math" alttext="\mathbf{A}=\begin{bmatrix}\mathbf{a}_{1}&amp;\cdots&amp;\mathbf{a}_{k}\end{bmatrix},%
+\hskip 14.22636pt\mathbf{B}=\begin{bmatrix}\mathbf{b}_{1}&amp;\cdots&amp;\mathbf{b}_{k%
+}\end{bmatrix}" display="block"><mrow><mrow><mi>𝐀</mi><mo>=</mo><mrow><mo>[</mo><mtable columnspacing="5pt" displaystyle="true"><mtr><mtd columnalign="center"><msub><mi>𝐚</mi><mn>1</mn></msub></mtd><mtd columnalign="center"><mi mathvariant="normal">⋯</mi></mtd><mtd columnalign="center"><msub><mi>𝐚</mi><mi>k</mi></msub></mtd></mtr></mtable><mo>]</mo></mrow></mrow><mo rspace="16.7pt">,</mo><mrow><mi>𝐁</mi><mo>=</mo><mrow><mo>[</mo><mtable columnspacing="5pt" displaystyle="true"><mtr><mtd columnalign="center"><msub><mi>𝐛</mi><mn>1</mn></msub></mtd><mtd columnalign="center"><mi mathvariant="normal">⋯</mi></mtd><mtd columnalign="center"><msub><mi>𝐛</mi><mi>k</mi></msub></mtd></mtr></mtable><mo>]</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S3.SS13.SSS2.1" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S3.SS13.SSS2.1.p1" class="ltx_para">
+<p id="S3.SS13.SSS2.1.p1.1" class="ltx_p">For each <math id="S3.SS13.SSS2.1.p1.1.m1" class="ltx_Math" alttext="(i,j)" display="inline"><mrow><mo stretchy="false">(</mo><mi>i</mi><mo>,</mo><mi>j</mi><mo stretchy="false">)</mo></mrow></math>, we have</p>
+<table id="S3.Ex49" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex49.m1" class="ltx_Math" alttext="\left[\sum_{\ell=1}^{k}\mathbf{a}_{\ell}\mathbf{b}_{\ell}^{\!\top\!}\right]_{%
+ij}=\sum_{\ell=1}^{k}[\mathbf{a}_{\ell}\mathbf{b}_{\ell}^{\!\top\!}]_{ij}=\sum%
+_{\ell=1}^{k}[\mathbf{a}_{\ell}]_{i}[\mathbf{b}_{\ell}]_{j}=\sum_{\ell=1}^{k}A%
+_{i\ell}B_{j\ell}" display="block"><mrow><msub><mrow><mo>[</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi mathvariant="normal">ℓ</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><mrow><msub><mi>𝐚</mi><mi mathvariant="normal">ℓ</mi></msub><mo>⁢</mo><msubsup><mi>𝐛</mi><mi mathvariant="normal">ℓ</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msubsup></mrow></mrow><mo>]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi mathvariant="normal">ℓ</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><msub><mrow><mo stretchy="false">[</mo><mrow><msub><mi>𝐚</mi><mi mathvariant="normal">ℓ</mi></msub><mo>⁢</mo><msubsup><mi>𝐛</mi><mi mathvariant="normal">ℓ</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msubsup></mrow><mo stretchy="false">]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi mathvariant="normal">ℓ</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><mrow><msub><mrow><mo stretchy="false">[</mo><msub><mi>𝐚</mi><mi mathvariant="normal">ℓ</mi></msub><mo stretchy="false">]</mo></mrow><mi>i</mi></msub><mo>⁢</mo><msub><mrow><mo stretchy="false">[</mo><msub><mi>𝐛</mi><mi mathvariant="normal">ℓ</mi></msub><mo stretchy="false">]</mo></mrow><mi>j</mi></msub></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi mathvariant="normal">ℓ</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><mrow><msub><mi>A</mi><mrow><mi>i</mi><mo>⁢</mo><mi mathvariant="normal">ℓ</mi></mrow></msub><mo>⁢</mo><msub><mi>B</mi><mrow><mi>j</mi><mo>⁢</mo><mi mathvariant="normal">ℓ</mi></mrow></msub></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS13.SSS2.1.p1.8" class="ltx_p">This last expression should be recognized as an inner product between the <math id="S3.SS13.SSS2.1.p1.2.m1" class="ltx_Math" alttext="i" display="inline"><mi>i</mi></math>th row of <math id="S3.SS13.SSS2.1.p1.3.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and the <math id="S3.SS13.SSS2.1.p1.4.m3" class="ltx_Math" alttext="j" display="inline"><mi>j</mi></math>th row of <math id="S3.SS13.SSS2.1.p1.5.m4" class="ltx_Math" alttext="\mathbf{B}" display="inline"><mi>𝐁</mi></math>, or equivalently the <math id="S3.SS13.SSS2.1.p1.6.m5" class="ltx_Math" alttext="j" display="inline"><mi>j</mi></math>th column of <math id="S3.SS13.SSS2.1.p1.7.m6" class="ltx_Math" alttext="\mathbf{B}^{\!\top\!}" display="inline"><msup><mi>𝐁</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></math>.
+Hence by the definition of matrix multiplication, it is equal to <math id="S3.SS13.SSS2.1.p1.8.m7" class="ltx_Math" alttext="[\mathbf{A}\mathbf{B}^{\!\top\!}]_{ij}" display="inline"><msub><mrow><mo stretchy="false">[</mo><msup><mi>𝐀𝐁</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo stretchy="false">]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub></math>.
+∎</p>
+</div>
+</div>
+</section>
+<section id="S3.SS13.SSS3" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">3.13.3 </span>Quadratic forms</h4>
+
+<div id="S3.SS13.SSS3.p1" class="ltx_para ltx_noindent">
+<p id="S3.SS13.SSS3.p1.5" class="ltx_p">Let <math id="S3.SS13.SSS3.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}\in\mathbb{R}^{n\times n}" display="inline"><mrow><mi>𝐀</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>n</mi><mo>×</mo><mi>n</mi></mrow></msup></mrow></math> be a symmetric matrix, and recall that the expression <math id="S3.SS13.SSS3.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></math> is called a quadratic form of <math id="S3.SS13.SSS3.p1.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>.
+It is in some cases helpful to rewrite the quadratic form in terms of the individual elements that make up <math id="S3.SS13.SSS3.p1.4.m4" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and <math id="S3.SS13.SSS3.p1.5.m5" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>:</p>
+<table id="S3.Ex50" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S3.Ex50.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}=\sum_{i=1}^{n}\sum_{j=1}^{n}A_{ij}x_%
+{i}x_{j}" display="block"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>j</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>A</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>⁢</mo><msub><mi>x</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>x</mi><mi>j</mi></msub></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S3.SS13.SSS3.p1.6" class="ltx_p">This identity is valid for any square matrix (need not be symmetric), although quadratic forms are usually only discussed in the context of symmetric matrices.</p>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+</section>
+</section>
+</section>
+<section id="S4" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">
+<span class="ltx_tag ltx_tag_section">4 </span>Calculus and Optimization</h2>
+
+<div id="S4.p1" class="ltx_para ltx_noindent">
+<p id="S4.p1.1" class="ltx_p">Much of machine learning is about minimizing a <span id="S4.p1.1.1" class="ltx_text ltx_font_bold">cost function</span> (also called an <span id="S4.p1.1.2" class="ltx_text ltx_font_bold">objective function</span> in the optimization community), which is a scalar function of several variables that typically measures how poorly our model fits the data we have.</p>
+</div>
+<section id="S4.SS1" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.1 </span>Extrema</h3>
+
+<div id="S4.SS1.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS1.p1.2" class="ltx_p">Optimization is about finding <span id="S4.SS1.p1.2.1" class="ltx_text ltx_font_bold">extrema</span>, which depending on the application could be minima or maxima.
+When defining extrema, it is necessary to consider the set of inputs over which we’re optimizing.
+This set <math id="S4.SS1.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}\subseteq\mathbb{R}^{d}" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>⊆</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow></math> is called the <span id="S4.SS1.p1.2.2" class="ltx_text ltx_font_bold">feasible set</span>.
+If <math id="S4.SS1.p1.2.m2" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> is the entire domain of the function being optimized (as it often will be for our purposes), we say that the problem is <span id="S4.SS1.p1.2.3" class="ltx_text ltx_font_bold">unconstrained</span>.
+Otherwise the problem is <span id="S4.SS1.p1.2.4" class="ltx_text ltx_font_bold">constrained</span> and may be much harder to solve, depending on the nature of the feasible set.</p>
+</div>
+<div id="S4.SS1.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS1.p2.15" class="ltx_p">Suppose <math id="S4.SS1.p2.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{d}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo>→</mo><mi>ℝ</mi></mrow></math>.
+A point <math id="S4.SS1.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is said to be a <span id="S4.SS1.p2.15.1" class="ltx_text ltx_font_bold">local minimum</span> (resp. <span id="S4.SS1.p2.15.2" class="ltx_text ltx_font_bold">local maximum</span>) of <math id="S4.SS1.p2.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS1.p2.4.m4" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> if <math id="S4.SS1.p2.5.m5" class="ltx_Math" alttext="f(\mathbf{x})\leq f(\mathbf{y})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> (resp. <math id="S4.SS1.p2.6.m6" class="ltx_Math" alttext="f(\mathbf{x})\geq f(\mathbf{y})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≥</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>) for all <math id="S4.SS1.p2.7.m7" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> in some neighborhood <math id="S4.SS1.p2.8.m8" class="ltx_Math" alttext="N\subseteq\mathcal{X}" display="inline"><mrow><mi>N</mi><mo>⊆</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> about <math id="S4.SS1.p2.9.m9" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>.<span id="footnote6" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">6</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">6</sup><span class="ltx_tag ltx_tag_note">6</span>
+A <span id="footnote6.1" class="ltx_text ltx_font_bold">neighborhood</span> about <math id="footnote6.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is an open set which contains <math id="footnote6.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>.
+</span></span></span>
+Furthermore, if <math id="S4.SS1.p2.10.m10" class="ltx_Math" alttext="f(\mathbf{x})\leq f(\mathbf{y})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all <math id="S4.SS1.p2.11.m11" class="ltx_Math" alttext="\mathbf{y}\in\mathcal{X}" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math>, then <math id="S4.SS1.p2.12.m12" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> is a <span id="S4.SS1.p2.15.3" class="ltx_text ltx_font_bold">global minimum</span> of <math id="S4.SS1.p2.13.m13" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS1.p2.14.m14" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> (similarly for global maximum).
+If the phrase “in <math id="S4.SS1.p2.15.m15" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>” is unclear from context, assume we are optimizing over the whole domain of the function.</p>
+</div>
+<div id="S4.SS1.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS1.p3.2" class="ltx_p">The qualifier <span id="S4.SS1.p3.2.1" class="ltx_text ltx_font_bold">strict</span> (as in e.g. a strict local minimum) means that the inequality sign in the definition is actually a <math id="S4.SS1.p3.1.m1" class="ltx_Math" alttext="&gt;" display="inline"><mo>&gt;</mo></math> or <math id="S4.SS1.p3.2.m2" class="ltx_Math" alttext="&lt;" display="inline"><mo>&lt;</mo></math>, with equality not allowed.
+This indicates that the extremum is unique within some neighborhood.</p>
+</div>
+<div id="S4.SS1.p4" class="ltx_para ltx_noindent">
+<p id="S4.SS1.p4.2" class="ltx_p">Observe that maximizing a function <math id="S4.SS1.p4.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is equivalent to minimizing <math id="S4.SS1.p4.2.m2" class="ltx_Math" alttext="-f" display="inline"><mrow><mo>-</mo><mi>f</mi></mrow></math>, so optimization problems are typically phrased in terms of minimization without loss of generality.
+This convention (which we follow here) eliminates the need to discuss minimization and maximization separately.</p>
+</div>
+</section>
+<section id="S4.SS2" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.2 </span>Gradients</h3>
+
+<div id="S4.SS2.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS2.p1.2" class="ltx_p">The single most important concept from calculus in the context of machine learning is the <span id="S4.SS2.p1.2.1" class="ltx_text ltx_font_bold">gradient</span>.
+Gradients generalize derivatives to scalar functions of several variables.
+The gradient of <math id="S4.SS2.p1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{d}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo>→</mo><mi>ℝ</mi></mrow></math>, denoted <math id="S4.SS2.p1.2.m2" class="ltx_Math" alttext="\nabla f" display="inline"><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow></math>, is given by</p>
+<table id="S4.Ex51" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex51.m1" class="ltx_Math" alttext="\nabla f=\begin{bmatrix}\partialderivative{f}{x_{1}}\\
+\vdots\\
+\partialderivative{f}{x_{n}}\end{bmatrix}\hskip 14.22636pt\text{i.e.}\hskip 14%
+.22636pt[\nabla f]_{i}=\partialderivative{f}{x_{i}}" display="block"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>=</mo><mrow><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><mi>f</mi></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow></mfrac></mstyle></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><mi>f</mi></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></mfrac></mstyle></mtd></mtr></mtable><mo>]</mo></mrow><mo mathvariant="italic" separator="true">  </mo><mtext>i.e.</mtext></mrow></mrow><mo mathvariant="italic" separator="true">  </mo><mrow><msub><mrow><mo stretchy="false">[</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo stretchy="false">]</mo></mrow><mi>i</mi></msub><mo>=</mo><mfrac><mrow><mo rspace="0pt">∂</mo><mi>f</mi></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>i</mi></msub></mrow></mfrac></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS2.p1.6" class="ltx_p">Gradients have the following very important property: <math id="S4.SS2.p1.3.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x})" display="inline"><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math> points in the direction of <span id="S4.SS2.p1.6.1" class="ltx_text ltx_font_bold">steepest ascent</span> from <math id="S4.SS2.p1.4.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>.
+Similarly, <math id="S4.SS2.p1.5.m3" class="ltx_Math" alttext="-\nabla f(\mathbf{x})" display="inline"><mrow><mo>-</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> points in the direction of <span id="S4.SS2.p1.6.2" class="ltx_text ltx_font_bold">steepest descent</span> from <math id="S4.SS2.p1.6.m4" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>.
+We will use this fact frequently when iteratively minimizing a function via <span id="S4.SS2.p1.6.3" class="ltx_text ltx_font_bold">gradient descent</span>.</p>
+</div>
+</section>
+<section id="S4.SS3" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.3 </span>The Jacobian</h3>
+
+<div id="S4.SS3.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS3.p1.1" class="ltx_p">The <span id="S4.SS3.p1.1.1" class="ltx_text ltx_font_bold">Jacobian</span> of <math id="S4.SS3.p1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{n}\to\mathbb{R}^{m}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo>→</mo><msup><mi>ℝ</mi><mi>m</mi></msup></mrow></math> is a matrix of first-order partial derivatives:</p>
+<table id="S4.Ex52" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex52.m1" class="ltx_Math" alttext="\mathbf{J}_{f}=\begin{bmatrix}\partialderivative{f_{1}}{x_{1}}&amp;\ldots&amp;%
+\partialderivative{f_{1}}{x_{n}}\\
+\vdots&amp;\ddots&amp;\vdots\\
+\partialderivative{f_{m}}{x_{1}}&amp;\ldots&amp;\partialderivative{f_{m}}{x_{n}}\end{%
+bmatrix}\hskip 14.22636pt\text{i.e.}\hskip 14.22636pt[\mathbf{J}_{f}]_{ij}=%
+\partialderivative{f_{i}}{x_{j}}" display="block"><mrow><mrow><msub><mi>𝐉</mi><mi>f</mi></msub><mo>=</mo><mrow><mrow><mo>[</mo><mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><msub><mi>f</mi><mn>1</mn></msub></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow></mfrac></mstyle></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><msub><mi>f</mi><mn>1</mn></msub></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></mfrac></mstyle></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋱</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><msub><mi>f</mi><mi>m</mi></msub></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow></mfrac></mstyle></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><mo rspace="0pt">∂</mo><msub><mi>f</mi><mi>m</mi></msub></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></mfrac></mstyle></mtd></mtr></mtable><mo>]</mo></mrow><mo mathvariant="italic" separator="true">  </mo><mtext>i.e.</mtext></mrow></mrow><mo mathvariant="italic" separator="true">  </mo><mrow><msub><mrow><mo stretchy="false">[</mo><msub><mi>𝐉</mi><mi>f</mi></msub><mo stretchy="false">]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mfrac><mrow><mo rspace="0pt">∂</mo><msub><mi>f</mi><mi>i</mi></msub></mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>j</mi></msub></mrow></mfrac></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS3.p1.3" class="ltx_p">Note the special case <math id="S4.SS3.p1.2.m1" class="ltx_Math" alttext="m=1" display="inline"><mrow><mi>m</mi><mo>=</mo><mn>1</mn></mrow></math>, where <math id="S4.SS3.p1.3.m2" class="ltx_Math" alttext="\nabla f=\mathbf{J}_{f}^{\!\top\!}" display="inline"><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>=</mo><msubsup><mi>𝐉</mi><mi>f</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msubsup></mrow></math>.</p>
+</div>
+</section>
+<section id="S4.SS4" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.4 </span>The Hessian</h3>
+
+<div id="S4.SS4.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS4.p1.1" class="ltx_p">The <span id="S4.SS4.p1.1.1" class="ltx_text ltx_font_bold">Hessian</span> matrix of <math id="S4.SS4.p1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{d}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo>→</mo><mi>ℝ</mi></mrow></math> is a matrix of second-order partial derivatives:</p>
+<table id="S4.Ex53" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex53.m1" class="ltx_Math" alttext="\nabla^{2}f=\begin{bmatrix}\partialderivative[2]{f}{x_{1}}&amp;\ldots&amp;%
+\partialderivative{f}{x_{1}}{x_{d}}\\
+\vdots&amp;\ddots&amp;\vdots\\
+\partialderivative{f}{x_{d}}{x_{1}}&amp;\ldots&amp;\partialderivative[2]{f}{x_{d}}\end%
+{bmatrix}\hskip 14.22636pt\text{i.e.}\hskip 14.22636pt[\nabla^{2}f]_{ij}={%
+\partialderivative{f}{x_{i}}{x_{j}}}" display="block"><mrow><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>=</mo><mrow><mrow><mo>[</mo><mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><msup><mo rspace="0pt">∂</mo><mn>2</mn></msup><mi>f</mi></mrow><msup><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow><mn>2</mn></msup></mfrac></mstyle></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><msup><mo rspace="0pt">∂</mo><mn>2</mn></msup><mi>f</mi></mrow><mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow><mo>⁢</mo><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>d</mi></msub></mrow></mrow></mfrac></mstyle></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋱</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><msup><mo rspace="0pt">∂</mo><mn>2</mn></msup><mi>f</mi></mrow><mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>d</mi></msub></mrow><mo>⁢</mo><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mn>1</mn></msub></mrow></mrow></mfrac></mstyle></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mstyle displaystyle="false"><mfrac><mrow><msup><mo rspace="0pt">∂</mo><mn>2</mn></msup><mi>f</mi></mrow><msup><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>d</mi></msub></mrow><mn>2</mn></msup></mfrac></mstyle></mtd></mtr></mtable><mo>]</mo></mrow><mo mathvariant="italic" separator="true">  </mo><mtext>i.e.</mtext></mrow></mrow><mo mathvariant="italic" separator="true">  </mo><mrow><msub><mrow><mo stretchy="false">[</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo stretchy="false">]</mo></mrow><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mfrac><mrow><msup><mo rspace="0pt">∂</mo><mn>2</mn></msup><mi>f</mi></mrow><mrow><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>i</mi></msub></mrow><mo>⁢</mo><mrow><mo rspace="0pt">∂</mo><msub><mi>x</mi><mi>j</mi></msub></mrow></mrow></mfrac></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS4.p1.2" class="ltx_p">Recall that if the partial derivatives are continuous, the order of differentiation can be interchanged (Clairaut’s theorem), so the Hessian matrix will be symmetric.
+This will typically be the case for differentiable functions that we work with.</p>
+</div>
+<div id="S4.SS4.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS4.p2.1" class="ltx_p">The Hessian is used in some optimization algorithms such as Newton’s method.
+It is expensive to calculate but can drastically reduce the number of iterations needed to converge to a local minimum by providing information about the curvature of <math id="S4.SS4.p2.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>.</p>
+</div>
+</section>
+<section id="S4.SS5" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.5 </span>Matrix calculus</h3>
+
+<div id="S4.SS5.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS5.p1.4" class="ltx_p">Since a lot of optimization reduces to finding points where the gradient vanishes, it is useful to have differentiation rules for matrix and vector expressions.
+We give some common rules here.
+Probably the two most important for our purposes are</p>
+<table id="Sx1.EGx3" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex54"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex54.m1" class="ltx_Math" alttext="\displaystyle\nabla_{\mathbf{x}}" display="inline"><msub><mo>∇</mo><mi>𝐱</mi></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex54.m2" class="ltx_Math" alttext="\displaystyle(\mathbf{a}^{\!\top\!}\mathbf{x})=\mathbf{a}" display="inline"><mrow><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐚</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow><mo>=</mo><mi>𝐚</mi></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex55"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex55.m1" class="ltx_Math" alttext="\displaystyle\nabla_{\mathbf{x}}" display="inline"><msub><mo>∇</mo><mi>𝐱</mi></msub></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex55.m2" class="ltx_Math" alttext="\displaystyle(\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x})=(\mathbf{A}+\mathbf{A%
+}^{\!\top\!})\mathbf{x}" display="inline"><mrow><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo stretchy="false">)</mo></mrow><mo>=</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀</mi><mo>+</mo><msup><mi>𝐀</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS5.p1.3" class="ltx_p">Note that this second rule is defined only if <math id="S4.SS5.p1.1.m1" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is square.
+Furthermore, if <math id="S4.SS5.p1.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> is symmetric, we can simplify the result to <math id="S4.SS5.p1.3.m3" class="ltx_Math" alttext="2\mathbf{A}\mathbf{x}" display="inline"><mrow><mn>2</mn><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></math>.</p>
+</div>
+<section id="S4.SS5.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.5.1 </span>The chain rule</h4>
+
+<div id="S4.SS5.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS5.SSS1.p1.1" class="ltx_p">Most functions that we wish to optimize are not completely arbitrary functions, but rather are composed of simpler functions which we know how to handle.
+The chain rule gives us a way to calculate derivatives for a composite function in terms of the derivatives of the simpler functions that make it up.</p>
+</div>
+<div id="S4.SS5.SSS1.p2" class="ltx_para">
+<p id="S4.SS5.SSS1.p2.2" class="ltx_p">The chain rule from single-variable calculus should be familiar:</p>
+<table id="S4.Ex56" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex56.m1" class="ltx_Math" alttext="(f\circ g)^{\prime}(x)=f^{\prime}(g(x))g^{\prime}(x)" display="block"><mrow><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>∘</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>f</mi><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><msup><mi>g</mi><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS5.SSS1.p2.1" class="ltx_p">where <math id="S4.SS5.SSS1.p2.1.m1" class="ltx_Math" alttext="\circ" display="inline"><mo>∘</mo></math> denotes function composition.
+There is a natural generalization of this rule to multivariate functions.</p>
+</div>
+<div id="Thmproposition8" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition8.1.1.1" class="ltx_text ltx_font_bold">Proposition 8</span></span><span id="Thmproposition8.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition8.p1" class="ltx_para">
+<p id="Thmproposition8.p1.3" class="ltx_p"><span id="Thmproposition8.p1.3.3" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition8.p1.1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{m}\to\mathbb{R}^{k}" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>m</mi></msup><mo mathvariant="normal">→</mo><msup><mi>ℝ</mi><mi>k</mi></msup></mrow></math> and <math id="Thmproposition8.p1.2.2.m2" class="ltx_Math" alttext="g\mathrel{\mathop{:}}\mathbb{R}^{n}\to\mathbb{R}^{m}" display="inline"><mrow><mi>g</mi><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo mathvariant="normal">→</mo><msup><mi>ℝ</mi><mi>m</mi></msup></mrow></math>. Then <math id="Thmproposition8.p1.3.3.m3" class="ltx_Math" alttext="f\circ g\mathrel{\mathop{:}}\mathbb{R}^{n}\to\mathbb{R}^{k}" display="inline"><mrow><mrow><mi>f</mi><mo mathvariant="normal">∘</mo><mi>g</mi></mrow><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo mathvariant="normal">→</mo><msup><mi>ℝ</mi><mi>k</mi></msup></mrow></math> and</span></p>
+<table id="S4.Ex57" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex57.m1" class="ltx_Math" alttext="\mathbf{J}_{f\circ g}(\mathbf{x})=\mathbf{J}_{f}(g(\mathbf{x}))\mathbf{J}_{g}(%
+\mathbf{x})" display="block"><mrow><mrow><msub><mi>𝐉</mi><mrow><mi>f</mi><mo>∘</mo><mi>g</mi></mrow></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msub><mi>𝐉</mi><mi>f</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><msub><mi>𝐉</mi><mi>g</mi></msub><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S4.SS5.SSS1.p3" class="ltx_para">
+<p id="S4.SS5.SSS1.p3.2" class="ltx_p">In the special case <math id="S4.SS5.SSS1.p3.1.m1" class="ltx_Math" alttext="k=1" display="inline"><mrow><mi>k</mi><mo>=</mo><mn>1</mn></mrow></math> we have the following corollary since <math id="S4.SS5.SSS1.p3.2.m2" class="ltx_Math" alttext="\nabla f=\mathbf{J}_{f}^{\!\top\!}" display="inline"><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>=</mo><msubsup><mi>𝐉</mi><mi>f</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msubsup></mrow></math>.</p>
+</div>
+<div id="Thmcorollary1" class="ltx_theorem ltx_theorem_corollary">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmcorollary1.1.1.1" class="ltx_text ltx_font_bold">Corollary 1</span></span><span id="Thmcorollary1.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmcorollary1.p1" class="ltx_para">
+<p id="Thmcorollary1.p1.3" class="ltx_p"><span id="Thmcorollary1.p1.3.3" class="ltx_text ltx_font_italic">Suppose <math id="Thmcorollary1.p1.1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{m}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>m</mi></msup><mo mathvariant="normal">→</mo><mi>ℝ</mi></mrow></math> and <math id="Thmcorollary1.p1.2.2.m2" class="ltx_Math" alttext="g\mathrel{\mathop{:}}\mathbb{R}^{n}\to\mathbb{R}^{m}" display="inline"><mrow><mi>g</mi><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo mathvariant="normal">→</mo><msup><mi>ℝ</mi><mi>m</mi></msup></mrow></math>. Then <math id="Thmcorollary1.p1.3.3.m3" class="ltx_Math" alttext="f\circ g\mathrel{\mathop{:}}\mathbb{R}^{n}\to\mathbb{R}" display="inline"><mrow><mrow><mi>f</mi><mo mathvariant="normal">∘</mo><mi>g</mi></mrow><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>n</mi></msup><mo mathvariant="normal">→</mo><mi>ℝ</mi></mrow></math> and</span></p>
+<table id="S4.Ex58" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex58.m1" class="ltx_Math" alttext="\nabla(f\circ g)(\mathbf{x})=\mathbf{J}_{g}(\mathbf{x})^{\!\top\!}\nabla f(g(%
+\mathbf{x}))" display="block"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>∘</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msub><mi>𝐉</mi><mi>g</mi></msub><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+</section>
+</section>
+<section id="S4.SS6" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.6 </span>Taylor’s theorem</h3>
+
+<div id="S4.SS6.p1" class="ltx_para">
+<p id="S4.SS6.p1.1" class="ltx_p">Taylor’s theorem has natural generalizations to functions of more than one variable.
+We give the version presented in <cite class="ltx_cite ltx_citemacro_cite">[<a href="#bib.bib3" title="Numerical optimization" class="ltx_ref">1</a>]</cite>.</p>
+</div>
+<div id="Thmtheorem4" class="ltx_theorem ltx_theorem_theorem">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmtheorem4.1.1.1" class="ltx_text ltx_font_bold">Theorem 4</span></span><span id="Thmtheorem4.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmtheorem4.p1" class="ltx_para">
+<p id="Thmtheorem4.p1.3" class="ltx_p"><span id="Thmtheorem4.p1.3.3" class="ltx_text ltx_font_italic">(Taylor’s theorem)
+Suppose <math id="Thmtheorem4.p1.1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{d}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">:</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo mathvariant="normal">→</mo><mi>ℝ</mi></mrow></math> is continuously differentiable, and let <math id="Thmtheorem4.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{h}\in\mathbb{R}^{d}" display="inline"><mrow><mi>𝐡</mi><mo mathvariant="normal">∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow></math>.
+Then there exists <math id="Thmtheorem4.p1.3.3.m3" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo mathvariant="normal">∈</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mn mathvariant="normal">0</mn><mo mathvariant="normal">,</mo><mn mathvariant="normal">1</mn><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></math> such that</span></p>
+<table id="S4.Ex59" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex59.m1" class="ltx_Math" alttext="f(\mathbf{x}+\mathbf{h})=f(\mathbf{x})+\nabla f(\mathbf{x}+t\mathbf{h})^{\!%
+\top\!}\mathbf{h}" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐡</mi></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmtheorem4.p1.4" class="ltx_p"><span id="Thmtheorem4.p1.4.1" class="ltx_text ltx_font_italic">Furthermore, if <math id="Thmtheorem4.p1.4.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is twice continuously differentiable, then</span></p>
+<table id="S4.Ex60" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex60.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x}+\mathbf{h})=\nabla f(\mathbf{x})+\int_{0}^{1}\nabla^{2}f(%
+\mathbf{x}+t\mathbf{h})\mathbf{h}\differential{t}" display="block"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mn>0</mn><mn>1</mn></msubsup><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>t</mi></mrow></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmtheorem4.p1.5" class="ltx_p"><span id="Thmtheorem4.p1.5.1" class="ltx_text ltx_font_italic">and there exists <math id="Thmtheorem4.p1.5.1.m1" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo mathvariant="normal">∈</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mn mathvariant="normal">0</mn><mo mathvariant="normal">,</mo><mn mathvariant="normal">1</mn><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></math> such that</span></p>
+<table id="S4.Ex61" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex61.m1" class="ltx_Math" alttext="f(\mathbf{x}+\mathbf{h})=f(\mathbf{x})+\nabla f(\mathbf{x})^{\!\top\!}\mathbf{%
+h}+\frac{1}{2}\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}+t\mathbf{h})\mathbf{h}" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐡</mi></mrow><mo>+</mo><mrow><mfrac><mn>1</mn><mn>2</mn></mfrac><mo>⁢</mo><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S4.SS6.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS6.p2.1" class="ltx_p">This theorem is used in proofs about conditions for local minima of unconstrained optimization problems.
+Some of the most important results are given in the next section.</p>
+</div>
+</section>
+<section id="S4.SS7" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.7 </span>Conditions for local minima</h3>
+
+<div id="Thmproposition9" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition9.1.1.1" class="ltx_text ltx_font_bold">Proposition 9</span></span><span id="Thmproposition9.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition9.p1" class="ltx_para">
+<p id="Thmproposition9.p1.5" class="ltx_p"><span id="Thmproposition9.p1.5.5" class="ltx_text ltx_font_italic">If <math id="Thmproposition9.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math> is a local minimum of <math id="Thmproposition9.p1.2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="Thmproposition9.p1.3.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is continuously differentiable in a neighborhood of <math id="Thmproposition9.p1.4.4.m4" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math>, then <math id="Thmproposition9.p1.5.5.m5" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo mathvariant="normal">∇</mo><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">=</mo><mn>𝟎</mn></mrow></math>.</span></p>
+</div>
+</div>
+<div id="S4.SS7.1" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS7.1.p1" class="ltx_para">
+<p id="S4.SS7.1.p1.5" class="ltx_p">Let <math id="S4.SS7.1.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> be a local minimum of <math id="S4.SS7.1.p1.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>, and suppose towards a contradiction that <math id="S4.SS7.1.p1.3.m3" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})\neq\mathbf{0}" display="inline"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>≠</mo><mn>𝟎</mn></mrow></math>.
+Let <math id="S4.SS7.1.p1.4.m4" class="ltx_Math" alttext="\mathbf{h}=-\nabla f(\mathbf{x}^{*})" display="inline"><mrow><mi>𝐡</mi><mo>=</mo><mrow><mo>-</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math>, noting that by the continuity of <math id="S4.SS7.1.p1.5.m5" class="ltx_Math" alttext="\nabla f" display="inline"><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow></math> we have</p>
+<table id="S4.Ex62" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex62.m1" class="ltx_Math" alttext="\lim_{t\to 0}-\nabla f(\mathbf{x}^{*}+t\mathbf{h})=-\nabla f(\mathbf{x}^{*})=%
+\mathbf{h}" display="block"><mrow><mrow><munder><mo movablelimits="false">lim</mo><mrow><mi>t</mi><mo>→</mo><mn>0</mn></mrow></munder><mo>-</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mo>-</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mi>𝐡</mi></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.1.p1.13" class="ltx_p">Hence</p>
+<table id="S4.Ex63" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex63.m1" class="ltx_Math" alttext="\lim_{t\to 0}\mathbf{h}^{\!\top\!}\nabla f(\mathbf{x}^{*}+t\mathbf{h})=\mathbf%
+{h}^{\!\top\!}\nabla f(\mathbf{x}^{*})=-\|\mathbf{h}\|_{2}^{2}&lt;0" display="block"><mrow><mrow><munder><mo movablelimits="false">lim</mo><mrow><mi>t</mi><mo>→</mo><mn>0</mn></mrow></munder><mo>⁡</mo><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo>-</mo><msubsup><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow><mo>&lt;</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.1.p1.10" class="ltx_p">Thus there exists <math id="S4.SS7.1.p1.6.m1" class="ltx_Math" alttext="T&gt;0" display="inline"><mrow><mi>T</mi><mo>&gt;</mo><mn>0</mn></mrow></math> such that <math id="S4.SS7.1.p1.7.m2" class="ltx_Math" alttext="\mathbf{h}^{\!\top\!}\nabla f(\mathbf{x}^{*}+t\mathbf{h})&lt;0" display="inline"><mrow><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mn>0</mn></mrow></math> for all <math id="S4.SS7.1.p1.8.m3" class="ltx_Math" alttext="t\in[0,T]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mi>T</mi><mo stretchy="false">]</mo></mrow></mrow></math>.
+Now we apply Taylor’s theorem: for any <math id="S4.SS7.1.p1.9.m4" class="ltx_Math" alttext="t\in(0,T]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mi>T</mi><mo stretchy="false">]</mo></mrow></mrow></math>, there exists <math id="S4.SS7.1.p1.10.m5" class="ltx_Math" alttext="t^{\prime}\in(0,t)" display="inline"><mrow><msup><mi>t</mi><mo>′</mo></msup><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow></math> such that</p>
+<table id="S4.Ex64" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex64.m1" class="ltx_Math" alttext="f(\mathbf{x}^{*}+t\mathbf{h})=f(\mathbf{x}^{*})+t\mathbf{h}^{\!\top\!}\nabla f%
+(\mathbf{x}^{*}+t^{\prime}\mathbf{h})&lt;f(\mathbf{x}^{*})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><msup><mi>t</mi><mo>′</mo></msup><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>&lt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.1.p1.12" class="ltx_p">whence it follows that <math id="S4.SS7.1.p1.11.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is not a local minimum, a contradiction.
+Hence <math id="S4.SS7.1.p1.12.m2" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>𝟎</mn></mrow></math>.
+∎</p>
+</div>
+</div>
+<div id="S4.SS7.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS7.p1.4" class="ltx_p">The proof shows us why the vanishing gradient is necessary for an extremum: if <math id="S4.SS7.p1.1.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x})" display="inline"><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math> is nonzero, there always exists a sufficiently small step <math id="S4.SS7.p1.2.m2" class="ltx_Math" alttext="\alpha&gt;0" display="inline"><mrow><mi>α</mi><mo>&gt;</mo><mn>0</mn></mrow></math> such that <math id="S4.SS7.p1.3.m3" class="ltx_Math" alttext="f(\mathbf{x}-\alpha\nabla f(\mathbf{x})))&lt;f(\mathbf{x})" display="inline"><mrow><mi>f</mi><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>-</mo><mi>α</mi><mo>∇</mo><mi>f</mi><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow><mo stretchy="false">)</mo></mrow><mo stretchy="false">)</mo><mo>&lt;</mo><mi>f</mi><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></math>.
+For this reason, <math id="S4.SS7.p1.4.m4" class="ltx_Math" alttext="-\nabla f(\mathbf{x})" display="inline"><mrow><mo>-</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> is called a <span id="S4.SS7.p1.4.1" class="ltx_text ltx_font_bold">descent direction</span>.</p>
+</div>
+<div id="S4.SS7.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS7.p2.7" class="ltx_p">Points where the gradient vanishes are called <span id="S4.SS7.p2.7.1" class="ltx_text ltx_font_bold">stationary points</span>.
+Note that not all stationary points are extrema.
+Consider <math id="S4.SS7.p2.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{2}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mn>2</mn></msup><mo>→</mo><mi>ℝ</mi></mrow></math> given by <math id="S4.SS7.p2.2.m2" class="ltx_Math" alttext="f(x,y)=x^{2}-y^{2}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>x</mi><mn>2</mn></msup><mo>-</mo><msup><mi>y</mi><mn>2</mn></msup></mrow></mrow></math>.
+We have <math id="S4.SS7.p2.3.m3" class="ltx_Math" alttext="\nabla f(\mathbf{0})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mn>𝟎</mn><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>𝟎</mn></mrow></math>, but the point <math id="S4.SS7.p2.4.m4" class="ltx_Math" alttext="\mathbf{0}" display="inline"><mn>𝟎</mn></math> is the minimum along the line <math id="S4.SS7.p2.5.m5" class="ltx_Math" alttext="y=0" display="inline"><mrow><mi>y</mi><mo>=</mo><mn>0</mn></mrow></math> and the maximum along the line <math id="S4.SS7.p2.6.m6" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math>.
+Thus it is neither a local minimum nor a local maximum of <math id="S4.SS7.p2.7.m7" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>.
+Points such as these, where the gradient vanishes but there is no local extremum, are called <span id="S4.SS7.p2.7.2" class="ltx_text ltx_font_bold">saddle points</span>.</p>
+</div>
+<div id="S4.SS7.p3" class="ltx_para">
+<p id="S4.SS7.p3.1" class="ltx_p">We have seen that first-order information (i.e. the gradient) is insufficient to characterize local minima.
+But we can say more with second-order information (i.e. the Hessian).
+First we prove a necessary second-order condition for local minima.</p>
+</div>
+<div id="Thmproposition10" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition10.1.1.1" class="ltx_text ltx_font_bold">Proposition 10</span></span><span id="Thmproposition10.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition10.p1" class="ltx_para">
+<p id="Thmproposition10.p1.5" class="ltx_p"><span id="Thmproposition10.p1.5.5" class="ltx_text ltx_font_italic">If <math id="Thmproposition10.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math> is a local minimum of <math id="Thmproposition10.p1.2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="Thmproposition10.p1.3.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is twice continuously differentiable in a neighborhood of <math id="Thmproposition10.p1.4.4.m4" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math>, then <math id="Thmproposition10.p1.5.5.m5" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo mathvariant="normal">∇</mo><mn mathvariant="normal">2</mn></msup><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></math> is positive semi-definite.</span></p>
+</div>
+</div>
+<div id="S4.SS7.2" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS7.2.p1" class="ltx_para">
+<p id="S4.SS7.2.p1.6" class="ltx_p">Let <math id="S4.SS7.2.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> be a local minimum of <math id="S4.SS7.2.p1.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>, and suppose towards a contradiction that <math id="S4.SS7.2.p1.3.m3" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></math> is not positive semi-definite.
+Let <math id="S4.SS7.2.p1.4.m4" class="ltx_Math" alttext="\mathbf{h}" display="inline"><mi>𝐡</mi></math> be such that <math id="S4.SS7.2.p1.5.m5" class="ltx_Math" alttext="\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}^{*})\mathbf{h}&lt;0" display="inline"><mrow><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow><mo>&lt;</mo><mn>0</mn></mrow></math>, noting that by the continuity of <math id="S4.SS7.2.p1.6.m6" class="ltx_Math" alttext="\nabla^{2}f" display="inline"><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow></math> we have</p>
+<table id="S4.Ex65" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex65.m1" class="ltx_Math" alttext="\lim_{t\to 0}\nabla^{2}f(\mathbf{x}^{*}+t\mathbf{h})=\nabla^{2}f(\mathbf{x}^{*})" display="block"><mrow><mrow><munder><mo movablelimits="false">lim</mo><mrow><mi>t</mi><mo>→</mo><mn>0</mn></mrow></munder><mo>⁡</mo><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.2.p1.15" class="ltx_p">Hence</p>
+<table id="S4.Ex66" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex66.m1" class="ltx_Math" alttext="\lim_{t\to 0}\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}^{*}+t\mathbf{h})%
+\mathbf{h}=\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}^{*})\mathbf{h}&lt;0" display="block"><mrow><mrow><munder><mo movablelimits="false">lim</mo><mrow><mi>t</mi><mo>→</mo><mn>0</mn></mrow></munder><mo>⁡</mo><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow><mo>&lt;</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.2.p1.11" class="ltx_p">Thus there exists <math id="S4.SS7.2.p1.7.m1" class="ltx_Math" alttext="T&gt;0" display="inline"><mrow><mi>T</mi><mo>&gt;</mo><mn>0</mn></mrow></math> such that <math id="S4.SS7.2.p1.8.m2" class="ltx_Math" alttext="\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}^{*}+t\mathbf{h})\mathbf{h}&lt;0" display="inline"><mrow><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow><mo>&lt;</mo><mn>0</mn></mrow></math> for all <math id="S4.SS7.2.p1.9.m3" class="ltx_Math" alttext="t\in[0,T]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mi>T</mi><mo stretchy="false">]</mo></mrow></mrow></math>.
+Now we apply Taylor’s theorem: for any <math id="S4.SS7.2.p1.10.m4" class="ltx_Math" alttext="t\in(0,T]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mi>T</mi><mo stretchy="false">]</mo></mrow></mrow></math>, there exists <math id="S4.SS7.2.p1.11.m5" class="ltx_Math" alttext="t^{\prime}\in(0,t)" display="inline"><mrow><msup><mi>t</mi><mo>′</mo></msup><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow></math> such that</p>
+<table id="S4.Ex67" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex67.m1" class="ltx_Math" alttext="f(\mathbf{x}^{*}+t\mathbf{h})=f(\mathbf{x}^{*})+\underbrace{t\mathbf{h}^{\!%
+\top\!}\nabla f(\mathbf{x}^{*})}_{0}+\frac{1}{2}t^{2}\mathbf{h}^{\!\top\!}%
+\nabla^{2}f(\mathbf{x}^{*}+t^{\prime}\mathbf{h})\mathbf{h}&lt;f(\mathbf{x}^{*})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><munder><munder accentunder="true"><mrow><mi>t</mi><mo movablelimits="false">⁢</mo><msup><mi>𝐡</mi><mo lspace="0.8pt" movablelimits="false" rspace="0.8pt">⊤</mo></msup><mo movablelimits="false">⁢</mo><mrow><mo movablelimits="false">∇</mo><mo movablelimits="false">⁡</mo><mi>f</mi></mrow><mo movablelimits="false">⁢</mo><mrow><mo movablelimits="false" stretchy="false">(</mo><msup><mi>𝐱</mi><mo movablelimits="false">*</mo></msup><mo movablelimits="false" stretchy="false">)</mo></mrow></mrow><mo movablelimits="false">⏟</mo></munder><mn>0</mn></munder><mo>+</mo><mrow><mfrac><mn>1</mn><mn>2</mn></mfrac><mo>⁢</mo><msup><mi>t</mi><mn>2</mn></msup><mo>⁢</mo><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><msup><mi>t</mi><mo>′</mo></msup><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo>&lt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.2.p1.14" class="ltx_p">where the middle term vanishes because <math id="S4.SS7.2.p1.12.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>𝟎</mn></mrow></math> by the previous result.
+It follows that <math id="S4.SS7.2.p1.13.m2" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is not a local minimum, a contradiction.
+Hence <math id="S4.SS7.2.p1.14.m3" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></math> is positive semi-definite.
+∎</p>
+</div>
+</div>
+<div id="S4.SS7.p4" class="ltx_para">
+<p id="S4.SS7.p4.1" class="ltx_p">Now we give sufficient conditions for local minima.</p>
+</div>
+<div id="Thmproposition11" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition11.1.1.1" class="ltx_text ltx_font_bold">Proposition 11</span></span><span id="Thmproposition11.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition11.p1" class="ltx_para">
+<p id="Thmproposition11.p1.8" class="ltx_p"><span id="Thmproposition11.p1.8.8" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition11.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is twice continuously differentiable with <math id="Thmproposition11.p1.2.2.m2" class="ltx_Math" alttext="\nabla^{2}f" display="inline"><mrow><msup><mo mathvariant="normal">∇</mo><mn mathvariant="normal">2</mn></msup><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow></math> positive semi-definite in a neighborhood of <math id="Thmproposition11.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math>, and that <math id="Thmproposition11.p1.4.4.m4" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo mathvariant="normal">∇</mo><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">=</mo><mn>𝟎</mn></mrow></math>.
+Then <math id="Thmproposition11.p1.5.5.m5" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math> is a local minimum of <math id="Thmproposition11.p1.6.6.m6" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>.
+Furthermore if <math id="Thmproposition11.p1.7.7.m7" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo mathvariant="normal">∇</mo><mn mathvariant="normal">2</mn></msup><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></math> is positive definite, then <math id="Thmproposition11.p1.8.8.m8" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo mathvariant="normal">*</mo></msup></math> is a strict local minimum.</span></p>
+</div>
+</div>
+<div id="S4.SS7.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS7.3.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS7.3.p1.6" class="ltx_p">Let <math id="S4.SS7.3.p1.1.m1" class="ltx_Math" alttext="B" display="inline"><mi>B</mi></math> be an open ball of radius <math id="S4.SS7.3.p1.2.m2" class="ltx_Math" alttext="r&gt;0" display="inline"><mrow><mi>r</mi><mo>&gt;</mo><mn>0</mn></mrow></math> centered at <math id="S4.SS7.3.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> which is contained in the neighborhood.
+Applying Taylor’s theorem, we have that for any <math id="S4.SS7.3.p1.4.m4" class="ltx_Math" alttext="\mathbf{h}" display="inline"><mi>𝐡</mi></math> with <math id="S4.SS7.3.p1.5.m5" class="ltx_Math" alttext="\|\mathbf{h}\|_{2}&lt;r" display="inline"><mrow><msub><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>&lt;</mo><mi>r</mi></mrow></math>, there exists <math id="S4.SS7.3.p1.6.m6" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo></mrow></mrow></math> such that</p>
+<table id="S4.Ex68" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex68.m1" class="ltx_Math" alttext="f(\mathbf{x}^{*}+\mathbf{h})=f(\mathbf{x}^{*})+\underbrace{\mathbf{h}^{\!\top%
+\!}\nabla f(\mathbf{x}^{*})}_{0}+\frac{1}{2}\mathbf{h}^{\!\top\!}\nabla^{2}f(%
+\mathbf{x}^{*}+t\mathbf{h})\mathbf{h}\geq f(\mathbf{x}^{*})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><munder><munder accentunder="true"><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" movablelimits="false" rspace="0.8pt">⊤</mo></msup><mo movablelimits="false">⁢</mo><mrow><mo movablelimits="false">∇</mo><mo movablelimits="false">⁡</mo><mi>f</mi></mrow><mo movablelimits="false">⁢</mo><mrow><mo movablelimits="false" stretchy="false">(</mo><msup><mi>𝐱</mi><mo movablelimits="false">*</mo></msup><mo movablelimits="false" stretchy="false">)</mo></mrow></mrow><mo movablelimits="false">⏟</mo></munder><mn>0</mn></munder><mo>+</mo><mrow><mfrac><mn>1</mn><mn>2</mn></mfrac><mo>⁢</mo><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo>≥</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS7.3.p1.13" class="ltx_p">The last inequality holds because <math id="S4.SS7.3.p1.7.m1" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*}+t\mathbf{h})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math> is positive semi-definite (since <math id="S4.SS7.3.p1.8.m2" class="ltx_Math" alttext="\|t\mathbf{h}\|_{2}=t\|\mathbf{h}\|_{2}&lt;\|\mathbf{h}\|_{2}&lt;r" display="inline"><mrow><msub><mrow><mo>∥</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow><mo>∥</mo></mrow><mn>2</mn></msub><mo>=</mo><mrow><mi>t</mi><mo>⁢</mo><msub><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn></msub></mrow><mo>&lt;</mo><msub><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>&lt;</mo><mi>r</mi></mrow></math>), so <math id="S4.SS7.3.p1.9.m3" class="ltx_Math" alttext="\mathbf{h}^{\!\top\!}\nabla^{2}f(\mathbf{x}^{*}+t\mathbf{h})\mathbf{h}\geq 0" display="inline"><mrow><mrow><msup><mi>𝐡</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐡</mi></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐡</mi></mrow><mo>≥</mo><mn>0</mn></mrow></math>.
+Since <math id="S4.SS7.3.p1.10.m4" class="ltx_Math" alttext="f(\mathbf{x}^{*})\leq f(\mathbf{x}^{*}+\mathbf{h})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all directions <math id="S4.SS7.3.p1.11.m5" class="ltx_Math" alttext="\mathbf{h}" display="inline"><mi>𝐡</mi></math> with <math id="S4.SS7.3.p1.12.m6" class="ltx_Math" alttext="\|\mathbf{h}\|_{2}&lt;r" display="inline"><mrow><msub><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>&lt;</mo><mi>r</mi></mrow></math>, we conclude that <math id="S4.SS7.3.p1.13.m7" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is a local minimum.</p>
+</div>
+<div id="S4.SS7.4.p2" class="ltx_para">
+<p id="S4.SS7.4.p2.10" class="ltx_p">Now further suppose that <math id="S4.SS7.4.p2.1.m1" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></math> is strictly positive definite.
+Since the Hessian is continuous we can choose another ball <math id="S4.SS7.4.p2.2.m2" class="ltx_Math" alttext="B^{\prime}" display="inline"><msup><mi>B</mi><mo>′</mo></msup></math> with radius <math id="S4.SS7.4.p2.3.m3" class="ltx_Math" alttext="r^{\prime}&gt;0" display="inline"><mrow><msup><mi>r</mi><mo>′</mo></msup><mo>&gt;</mo><mn>0</mn></mrow></math> centered at <math id="S4.SS7.4.p2.4.m4" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> such that <math id="S4.SS7.4.p2.5.m5" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math> is positive definite for all <math id="S4.SS7.4.p2.6.m6" class="ltx_Math" alttext="\mathbf{x}\in B^{\prime}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>B</mi><mo>′</mo></msup></mrow></math>.
+Then following the same argument as above (except with a strict inequality now since the Hessian is positive definite) we have <math id="S4.SS7.4.p2.7.m7" class="ltx_Math" alttext="f(\mathbf{x}^{*}+\mathbf{h})&gt;f(\mathbf{x}^{*})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mi>𝐱</mi><mo>*</mo></msup><mo>+</mo><mi>𝐡</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>&gt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all <math id="S4.SS7.4.p2.8.m8" class="ltx_Math" alttext="\mathbf{h}" display="inline"><mi>𝐡</mi></math> with <math id="S4.SS7.4.p2.9.m9" class="ltx_Math" alttext="0&lt;\|\mathbf{h}\|_{2}&lt;r^{\prime}" display="inline"><mrow><mn>0</mn><mo>&lt;</mo><msub><mrow><mo>∥</mo><mi>𝐡</mi><mo>∥</mo></mrow><mn>2</mn></msub><mo>&lt;</mo><msup><mi>r</mi><mo>′</mo></msup></mrow></math>.
+Hence <math id="S4.SS7.4.p2.10.m10" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is a strict local minimum.
+∎</p>
+</div>
+</div>
+<div id="S4.SS7.p5" class="ltx_para ltx_noindent">
+<p id="S4.SS7.p5.13" class="ltx_p">Note that, perhaps counterintuitively, the conditions <math id="S4.SS7.p5.1.m1" class="ltx_Math" alttext="\nabla f(\mathbf{x}^{*})=\mathbf{0}" display="inline"><mrow><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>𝟎</mn></mrow></math> and <math id="S4.SS7.p5.2.m2" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></math> positive semi-definite are not enough to guarantee a local minimum at <math id="S4.SS7.p5.3.m3" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math>!
+Consider the function <math id="S4.SS7.p5.4.m4" class="ltx_Math" alttext="f(x)=x^{3}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msup><mi>x</mi><mn>3</mn></msup></mrow></math>.
+We have <math id="S4.SS7.p5.5.m5" class="ltx_Math" alttext="f^{\prime}(0)=0" display="inline"><mrow><mrow><msup><mi>f</mi><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math> and <math id="S4.SS7.p5.6.m6" class="ltx_Math" alttext="f^{\prime\prime}(0)=0" display="inline"><mrow><mrow><msup><mi>f</mi><mo>′′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math> (so the Hessian, which in this case is the <math id="S4.SS7.p5.7.m7" class="ltx_Math" alttext="1\times 1" display="inline"><mrow><mn>1</mn><mo>×</mo><mn>1</mn></mrow></math> matrix <math id="S4.SS7.p5.8.m8" class="ltx_Math" alttext="\begin{bmatrix}0\end{bmatrix}" display="inline"><mrow><mo>[</mo><mtable><mtr><mtd columnalign="center"><mn>0</mn></mtd></mtr></mtable><mo>]</mo></mrow></math>, is positive semi-definite).
+But <math id="S4.SS7.p5.9.m9" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> has a saddle point at <math id="S4.SS7.p5.10.m10" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math>.
+The function <math id="S4.SS7.p5.11.m11" class="ltx_Math" alttext="f(x)=-x^{4}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo>-</mo><msup><mi>x</mi><mn>4</mn></msup></mrow></mrow></math> is an even worse offender – it has the same gradient and Hessian at <math id="S4.SS7.p5.12.m12" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math>, but <math id="S4.SS7.p5.13.m13" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math> is a strict local maximum for this function!</p>
+</div>
+<div id="S4.SS7.p6" class="ltx_para ltx_noindent">
+<p id="S4.SS7.p6.5" class="ltx_p">For these reasons we require that the Hessian remains positive semi-definite as long as we are close to <math id="S4.SS7.p6.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math>.
+Unfortunately, this condition is not practical to check computationally, but in some cases we can verify it analytically (usually by showing that <math id="S4.SS7.p6.2.m2" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></math> is p.s.d. for all <math id="S4.SS7.p6.3.m3" class="ltx_Math" alttext="\mathbf{x}\in\mathbb{R}^{d}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow></math>).
+Also, if <math id="S4.SS7.p6.4.m4" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x}^{*})" display="inline"><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></math> is strictly positive definite, the continuity assumption on <math id="S4.SS7.p6.5.m5" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> implies this condition, so we don’t have to worry.
+</p>
+</div>
+</section>
+<section id="S4.SS8" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.8 </span>Convexity</h3>
+
+<div id="S4.SS8.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.p1.1" class="ltx_p"><span id="S4.SS8.p1.1.1" class="ltx_text ltx_font_bold">Convexity</span> is a term that pertains to both sets and functions.
+For functions, there are different degrees of convexity, and how convex a function is tells us a lot about its minima: do they exist, are they unique, how quickly can we find them using optimization algorithms, etc.
+In this section, we present basic results regarding convexity, strict convexity, and strong convexity.</p>
+</div>
+<section id="S4.SS8.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.8.1 </span>Convex sets</h4>
+
+<figure id="S4.F1" class="ltx_figure">
+<div class="ltx_flex_figure">
+
+<div class="ltx_flex_cell 
+                  ltx_flex_size_2">
+<figure id="S4.F0.sf1" class="ltx_figure ltx_flex_size_2 ltx_align_center"><img src="convex-set.png" id="S4.F0.sf1.g1" class="ltx_graphics ltx_img_square" width="598" height="566" alt="">
+<figcaption class="ltx_caption"><span class="ltx_tag ltx_tag_figure"><span id="S4.F0.sf1.2.1.1" class="ltx_text" style="font-size:90%;">(a)</span> </span><span id="S4.F0.sf1.3.2" class="ltx_text" style="font-size:90%;">A convex set</span></figcaption>
+</figure>
+</div>
+<div class="ltx_flex_cell 
+                  ltx_flex_size_2">
+<figure id="S4.F0.sf2" class="ltx_figure ltx_flex_size_2 ltx_align_center"><img src="nonconvex-set.png" id="S4.F0.sf2.g1" class="ltx_graphics ltx_img_square" width="598" height="566" alt="">
+<figcaption class="ltx_caption"><span class="ltx_tag ltx_tag_figure"><span id="S4.F0.sf2.2.1.1" class="ltx_text" style="font-size:90%;">(b)</span> </span><span id="S4.F0.sf2.3.2" class="ltx_text" style="font-size:90%;">A non-convex set</span></figcaption>
+</figure>
+</div>
+</div>
+<figcaption class="ltx_caption ltx_centering"><span class="ltx_tag ltx_tag_figure"><span id="S4.F1.2.1.1" class="ltx_text" style="font-size:90%;">Figure 1</span>: </span><span id="S4.F1.3.2" class="ltx_text" style="font-size:90%;">What convex sets look like</span></figcaption>
+</figure>
+<div id="S4.SS8.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS1.p1.1" class="ltx_p">A set <math id="S4.SS8.SSS1.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}\subseteq\mathbb{R}^{d}" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>⊆</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow></math> is <span id="S4.SS8.SSS1.p1.1.1" class="ltx_text ltx_font_bold">convex</span> if</p>
+<table id="S4.Ex69" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex69.m1" class="ltx_Math" alttext="t\mathbf{x}+(1-t)\mathbf{y}\in\mathcal{X}" display="block"><mrow><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS1.p1.3" class="ltx_p">for all <math id="S4.SS8.SSS1.p1.2.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\mathcal{X}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> and all <math id="S4.SS8.SSS1.p1.3.m2" class="ltx_Math" alttext="t\in[0,1]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS1.p2.2" class="ltx_p">Geometrically, this means that all the points on the line segment between any two points in <math id="S4.SS8.SSS1.p2.1.m1" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> are also in <math id="S4.SS8.SSS1.p2.2.m2" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+See Figure <a href="#S4.F1" title="Figure 1 ‣ 4.8.1 Convex sets ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_tag">1</span></a> for a visual.</p>
+</div>
+<div id="S4.SS8.SSS1.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS1.p3.1" class="ltx_p">Why do we care whether or not a set is convex?
+We will see later that the nature of minima can depend greatly on whether or not the feasible set is convex.
+Undesirable pathological results can occur when we allow the feasible set to be arbitrary, so for proofs we will need to assume that it is convex.
+Fortunately, we often want to minimize over all of <math id="S4.SS8.SSS1.p3.1.m1" class="ltx_Math" alttext="\mathbb{R}^{d}" display="inline"><msup><mi>ℝ</mi><mi>d</mi></msup></math>, which is easily seen to be a convex set.</p>
+</div>
+</section>
+<section id="S4.SS8.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.8.2 </span>Basics of convex functions</h4>
+
+<div id="S4.SS8.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p1.1" class="ltx_p">In the remainder of this section, assume <math id="S4.SS8.SSS2.p1.1.m1" class="ltx_Math" alttext="f\mathrel{\mathop{:}}\mathbb{R}^{d}\to\mathbb{R}" display="inline"><mrow><mi>f</mi><mo>:</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo>→</mo><mi>ℝ</mi></mrow></math> unless otherwise noted. We’ll start with the definitions and then give some results.</p>
+</div>
+<div id="S4.SS8.SSS2.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p2.1" class="ltx_p">A function <math id="S4.SS8.SSS2.p2.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is <span id="S4.SS8.SSS2.p2.1.1" class="ltx_text ltx_font_bold">convex</span> if</p>
+<table id="S4.Ex70" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex70.m1" class="ltx_Math" alttext="f(t\mathbf{x}+(1-t)\mathbf{y})\leq tf(\mathbf{x})+(1-t)f(\mathbf{y})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS2.p2.3" class="ltx_p">for all <math id="S4.SS8.SSS2.p2.2.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}f" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow></mrow></math> and all <math id="S4.SS8.SSS2.p2.3.m2" class="ltx_Math" alttext="t\in[0,1]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS2.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p3.5" class="ltx_p">If the inequality holds strictly (i.e. <math id="S4.SS8.SSS2.p3.1.m1" class="ltx_Math" alttext="&lt;" display="inline"><mo>&lt;</mo></math> rather than <math id="S4.SS8.SSS2.p3.2.m2" class="ltx_Math" alttext="\leq" display="inline"><mo>≤</mo></math>) for all <math id="S4.SS8.SSS2.p3.3.m3" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo></mrow></mrow></math> and <math id="S4.SS8.SSS2.p3.4.m4" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mi>𝐲</mi></mrow></math>, then we say that <math id="S4.SS8.SSS2.p3.5.m5" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is <span id="S4.SS8.SSS2.p3.5.1" class="ltx_text ltx_font_bold">strictly convex</span>.</p>
+</div>
+<div id="S4.SS8.SSS2.p4" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p4.3" class="ltx_p">A function <math id="S4.SS8.SSS2.p4.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is <span id="S4.SS8.SSS2.p4.2.1" class="ltx_text ltx_font_bold">strongly convex with parameter <math id="S4.SS8.SSS2.p4.2.1.m1" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math></span> (or <math id="S4.SS8.SSS2.p4.3.m2" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math><span id="S4.SS8.SSS2.p4.3.2" class="ltx_text ltx_font_bold">-strongly convex</span>) if the function</p>
+<table id="S4.Ex71" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex71.m1" class="ltx_Math" alttext="\mathbf{x}\mapsto f(\mathbf{x})-\frac{m}{2}\|\mathbf{x}\|_{2}^{2}" display="block"><mrow><mi>𝐱</mi><mo>↦</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>-</mo><mrow><mfrac><mi>m</mi><mn>2</mn></mfrac><mo>⁢</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS2.p4.4" class="ltx_p">is convex.</p>
+</div>
+<div id="S4.SS8.SSS2.p5" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p5.1" class="ltx_p">These conditions are given in increasing order of strength; strong convexity implies strict convexity which implies convexity.</p>
+</div>
+<figure id="S4.F2" class="ltx_figure"><img src="convex-function.png" id="S4.F2.g1" class="ltx_graphics ltx_centering ltx_img_landscape" width="598" height="311" alt="">
+<figcaption class="ltx_caption ltx_centering"><span class="ltx_tag ltx_tag_figure"><span id="S4.F2.2.1.1" class="ltx_text" style="font-size:90%;">Figure 2</span>: </span><span id="S4.F2.3.2" class="ltx_text" style="font-size:90%;">What convex functions look like</span></figcaption>
+</figure>
+<div id="S4.SS8.SSS2.p6" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p6.1" class="ltx_p">Geometrically, convexity means that the line segment between two points on the graph of <math id="S4.SS8.SSS2.p6.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> lies on or above the graph itself.
+See Figure <a href="#S4.F2" title="Figure 2 ‣ 4.8.2 Basics of convex functions ‣ 4.8 Convexity ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_tag">2</span></a> for a visual.</p>
+</div>
+<div id="S4.SS8.SSS2.p7" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS2.p7.1" class="ltx_p">Strict convexity means that the graph of <math id="S4.SS8.SSS2.p7.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> lies strictly above the line segment, except at the segment endpoints.
+(So actually the function in the figure appears to be strictly convex.)</p>
+</div>
+</section>
+<section id="S4.SS8.SSS3" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.8.3 </span>Consequences of convexity</h4>
+
+<div id="S4.SS8.SSS3.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.p1.1" class="ltx_p">Why do we care if a function is (strictly/strongly) convex?</p>
+</div>
+<div id="S4.SS8.SSS3.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.p2.1" class="ltx_p">Basically, our various notions of convexity have implications about the nature of minima.
+It should not be surprising that the stronger conditions tell us more about the minima.</p>
+</div>
+<div id="Thmproposition12" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition12.1.1.1" class="ltx_text ltx_font_bold">Proposition 12</span></span><span id="Thmproposition12.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition12.p1" class="ltx_para">
+<p id="Thmproposition12.p1.4" class="ltx_p"><span id="Thmproposition12.p1.4.4" class="ltx_text ltx_font_italic">Let <math id="Thmproposition12.p1.1.1.m1" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> be a convex set.
+If <math id="Thmproposition12.p1.2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex, then any local minimum of <math id="Thmproposition12.p1.3.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="Thmproposition12.p1.4.4.m4" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> is also a global minimum.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS3.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS3.1.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.1.p1.10" class="ltx_p">Suppose <math id="S4.SS8.SSS3.1.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex, and let <math id="S4.SS8.SSS3.1.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> be a local minimum of <math id="S4.SS8.SSS3.1.p1.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS8.SSS3.1.p1.4.m4" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+Then for some neighborhood <math id="S4.SS8.SSS3.1.p1.5.m5" class="ltx_Math" alttext="N\subseteq\mathcal{X}" display="inline"><mrow><mi>N</mi><mo>⊆</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> about <math id="S4.SS8.SSS3.1.p1.6.m6" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math>, we have <math id="S4.SS8.SSS3.1.p1.7.m7" class="ltx_Math" alttext="f(\mathbf{x})\geq f(\mathbf{x}^{*})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≥</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all <math id="S4.SS8.SSS3.1.p1.8.m8" class="ltx_Math" alttext="\mathbf{x}\in N" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>N</mi></mrow></math>.
+Suppose towards a contradiction that there exists <math id="S4.SS8.SSS3.1.p1.9.m9" class="ltx_Math" alttext="\tilde{\mathbf{x}}\in\mathcal{X}" display="inline"><mrow><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> such that <math id="S4.SS8.SSS3.1.p1.10.m10" class="ltx_Math" alttext="f(\tilde{\mathbf{x}})&lt;f(\mathbf{x}^{*})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS3.2.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.2.p2.4" class="ltx_p">Consider the line segment <math id="S4.SS8.SSS3.2.p2.1.m1" class="ltx_Math" alttext="\mathbf{x}(t)=t\mathbf{x}^{*}+(1-t)\tilde{\mathbf{x}},~{}t\in[0,1]" display="inline"><mrow><mrow><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><msup><mi>𝐱</mi><mo>*</mo></msup></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow></mrow></mrow><mo rspace="5.8pt">,</mo><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></mrow></math>, noting that <math id="S4.SS8.SSS3.2.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}(t)\in\mathcal{X}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> by the convexity of <math id="S4.SS8.SSS3.2.p2.3.m3" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+Then by the convexity of <math id="S4.SS8.SSS3.2.p2.4.m4" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>,</p>
+<table id="S4.Ex72" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex72.m1" class="ltx_Math" alttext="f(\mathbf{x}(t))\leq tf(\mathbf{x}^{*})+(1-t)f(\tilde{\mathbf{x}})&lt;tf(\mathbf{%
+x}^{*})+(1-t)f(\mathbf{x}^{*})=f(\mathbf{x}^{*})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>&lt;</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS3.2.p2.5" class="ltx_p">for all <math id="S4.SS8.SSS3.2.p2.5.m1" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo></mrow></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS3.3.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.3.p3.6" class="ltx_p">We can pick <math id="S4.SS8.SSS3.3.p3.1.m1" class="ltx_Math" alttext="t" display="inline"><mi>t</mi></math> to be sufficiently close to <math id="S4.SS8.SSS3.3.p3.2.m2" class="ltx_Math" alttext="1" display="inline"><mn>1</mn></math> that <math id="S4.SS8.SSS3.3.p3.3.m3" class="ltx_Math" alttext="\mathbf{x}(t)\in N" display="inline"><mrow><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo>∈</mo><mi>N</mi></mrow></math>; then <math id="S4.SS8.SSS3.3.p3.4.m4" class="ltx_Math" alttext="f(\mathbf{x}(t))\geq f(\mathbf{x}^{*})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>≥</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math> by the definition of <math id="S4.SS8.SSS3.3.p3.5.m5" class="ltx_Math" alttext="N" display="inline"><mi>N</mi></math>, but <math id="S4.SS8.SSS3.3.p3.6.m6" class="ltx_Math" alttext="f(\mathbf{x}(t))&lt;f(\mathbf{x}^{*})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math> by the above inequality, a contradiction.</p>
+</div>
+<div id="S4.SS8.SSS3.4.p4" class="ltx_para">
+<p id="S4.SS8.SSS3.4.p4.5" class="ltx_p">It follows that <math id="S4.SS8.SSS3.4.p4.1.m1" class="ltx_Math" alttext="f(\mathbf{x}^{*})\leq f(\mathbf{x})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for all <math id="S4.SS8.SSS3.4.p4.2.m2" class="ltx_Math" alttext="\mathbf{x}\in\mathcal{X}" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math>, so <math id="S4.SS8.SSS3.4.p4.3.m3" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is a global minimum of <math id="S4.SS8.SSS3.4.p4.4.m4" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS8.SSS3.4.p4.5.m5" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition13" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition13.1.1.1" class="ltx_text ltx_font_bold">Proposition 13</span></span><span id="Thmproposition13.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition13.p1" class="ltx_para">
+<p id="Thmproposition13.p1.6" class="ltx_p"><span id="Thmproposition13.p1.6.6" class="ltx_text ltx_font_italic">Let <math id="Thmproposition13.p1.1.1.m1" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> be a convex set.
+If <math id="Thmproposition13.p1.2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is strictly convex, then there exists at most one local minimum of <math id="Thmproposition13.p1.3.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="Thmproposition13.p1.4.4.m4" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+Consequently, if it exists it is the unique global minimum of <math id="Thmproposition13.p1.5.5.m5" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="Thmproposition13.p1.6.6.m6" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS3.7" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS3.5.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.5.p1.1" class="ltx_p">The second sentence follows from the first, so all we must show is that if a local minimum exists in <math id="S4.SS8.SSS3.5.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> then it is unique.</p>
+</div>
+<div id="S4.SS8.SSS3.6.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.6.p2.5" class="ltx_p">Suppose <math id="S4.SS8.SSS3.6.p2.1.m1" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is a local minimum of <math id="S4.SS8.SSS3.6.p2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS8.SSS3.6.p2.3.m3" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>, and suppose towards a contradiction that there exists a local minimum <math id="S4.SS8.SSS3.6.p2.4.m4" class="ltx_Math" alttext="\tilde{\mathbf{x}}\in\mathcal{X}" display="inline"><mrow><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> such that <math id="S4.SS8.SSS3.6.p2.5.m5" class="ltx_Math" alttext="\tilde{\mathbf{x}}\neq\mathbf{x}^{*}" display="inline"><mrow><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo>≠</mo><msup><mi>𝐱</mi><mo>*</mo></msup></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS3.7.p3" class="ltx_para">
+<p id="S4.SS8.SSS3.7.p3.9" class="ltx_p">Since <math id="S4.SS8.SSS3.7.p3.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is strictly convex, it is convex, so <math id="S4.SS8.SSS3.7.p3.2.m2" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> and <math id="S4.SS8.SSS3.7.p3.3.m3" class="ltx_Math" alttext="\tilde{\mathbf{x}}" display="inline"><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></math> are both global minima of <math id="S4.SS8.SSS3.7.p3.4.m4" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS8.SSS3.7.p3.5.m5" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> by the previous result.
+Hence <math id="S4.SS8.SSS3.7.p3.6.m6" class="ltx_Math" alttext="f(\mathbf{x}^{*})=f(\tilde{\mathbf{x}})" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+Consider the line segment <math id="S4.SS8.SSS3.7.p3.7.m7" class="ltx_Math" alttext="\mathbf{x}(t)=t\mathbf{x}^{*}+(1-t)\tilde{\mathbf{x}},~{}t\in[0,1]" display="inline"><mrow><mrow><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><msup><mi>𝐱</mi><mo>*</mo></msup></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow></mrow></mrow><mo rspace="5.8pt">,</mo><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></mrow></math>, which again must lie entirely in <math id="S4.SS8.SSS3.7.p3.8.m8" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+By the strict convexity of <math id="S4.SS8.SSS3.7.p3.9.m9" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math>,</p>
+<table id="S4.Ex73" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex73.m1" class="ltx_Math" alttext="f(\mathbf{x}(t))&lt;tf(\mathbf{x}^{*})+(1-t)f(\tilde{\mathbf{x}})=tf(\mathbf{x}^{%
+*})+(1-t)f(\mathbf{x}^{*})=f(\mathbf{x}^{*})" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>𝐱</mi><mo>*</mo></msup><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS3.7.p3.17" class="ltx_p">for all <math id="S4.SS8.SSS3.7.p3.10.m1" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo></mrow></mrow></math>.
+But this contradicts the fact that <math id="S4.SS8.SSS3.7.p3.11.m2" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is a global minimum.
+Therefore if <math id="S4.SS8.SSS3.7.p3.12.m3" class="ltx_Math" alttext="\tilde{\mathbf{x}}" display="inline"><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></math> is a local minimum of <math id="S4.SS8.SSS3.7.p3.13.m4" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> in <math id="S4.SS8.SSS3.7.p3.14.m5" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>, then <math id="S4.SS8.SSS3.7.p3.15.m6" class="ltx_Math" alttext="\tilde{\mathbf{x}}=\mathbf{x}^{*}" display="inline"><mrow><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo>=</mo><msup><mi>𝐱</mi><mo>*</mo></msup></mrow></math>, so <math id="S4.SS8.SSS3.7.p3.16.m7" class="ltx_Math" alttext="\mathbf{x}^{*}" display="inline"><msup><mi>𝐱</mi><mo>*</mo></msup></math> is the unique minimum in <math id="S4.SS8.SSS3.7.p3.17.m8" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+∎</p>
+</div>
+</div>
+<div id="S4.SS8.SSS3.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.p3.1" class="ltx_p">It is worthwhile to examine how the feasible set affects the optimization problem.
+We will see why the assumption that <math id="S4.SS8.SSS3.p3.1.m1" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math> is convex is needed in the results above.</p>
+</div>
+<div id="S4.SS8.SSS3.p4" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS3.p4.4" class="ltx_p">Consider the function <math id="S4.SS8.SSS3.p4.1.m1" class="ltx_Math" alttext="f(x)=x^{2}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></math>, which is a strictly convex function.
+The unique global minimum of this function in <math id="S4.SS8.SSS3.p4.2.m2" class="ltx_Math" alttext="\mathbb{R}" display="inline"><mi>ℝ</mi></math> is <math id="S4.SS8.SSS3.p4.3.m3" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math>.
+But let’s see what happens when we change the feasible set <math id="S4.SS8.SSS3.p4.4.m4" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.</p>
+<ol id="S4.I1" class="ltx_enumerate">
+<li id="S4.I1.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S4.I1.i1.p1" class="ltx_para ltx_noindent">
+<p id="S4.I1.i1.p1.1" class="ltx_p"><math id="S4.I1.i1.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}=\{1\}" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>=</mo><mrow><mo stretchy="false">{</mo><mn>1</mn><mo stretchy="false">}</mo></mrow></mrow></math>: This set is actually convex, so we still have a unique global minimum.
+But it is not the same as the unconstrained minimum!</p>
+</div>
+</li>
+<li id="S4.I1.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S4.I1.i2.p1" class="ltx_para ltx_noindent">
+<p id="S4.I1.i2.p1.6" class="ltx_p"><math id="S4.I1.i2.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}=\mathbb{R}\setminus\{0\}" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>=</mo><mrow><mi>ℝ</mi><mo>∖</mo><mrow><mo stretchy="false">{</mo><mn>0</mn><mo stretchy="false">}</mo></mrow></mrow></mrow></math>: This set is non-convex, and we can see that <math id="S4.I1.i2.p1.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> has no minima in <math id="S4.I1.i2.p1.3.m3" class="ltx_Math" alttext="\mathcal{X}" display="inline"><mi class="ltx_font_mathcaligraphic">𝒳</mi></math>.
+For any point <math id="S4.I1.i2.p1.4.m4" class="ltx_Math" alttext="x\in\mathcal{X}" display="inline"><mrow><mi>x</mi><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math>, one can find another point <math id="S4.I1.i2.p1.5.m5" class="ltx_Math" alttext="y\in\mathcal{X}" display="inline"><mrow><mi>y</mi><mo>∈</mo><mi class="ltx_font_mathcaligraphic">𝒳</mi></mrow></math> such that <math id="S4.I1.i2.p1.6.m6" class="ltx_Math" alttext="f(y)&lt;f(x)" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>&lt;</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.</p>
+</div>
+</li>
+<li id="S4.I1.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S4.I1.i3.p1" class="ltx_para ltx_noindent">
+<p id="S4.I1.i3.p1.3" class="ltx_p"><math id="S4.I1.i3.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}=(-\infty,-1]\cup[0,\infty)" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>=</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mo>-</mo><mi mathvariant="normal">∞</mi></mrow><mo>,</mo><mrow><mo>-</mo><mn>1</mn></mrow><mo stretchy="false">]</mo></mrow><mo>∪</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mi mathvariant="normal">∞</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>: This set is non-convex, and we can see that there is a local minimum (<math id="S4.I1.i3.p1.2.m2" class="ltx_Math" alttext="x=-1" display="inline"><mrow><mi>x</mi><mo>=</mo><mrow><mo>-</mo><mn>1</mn></mrow></mrow></math>) which is distinct from the global minimum (<math id="S4.I1.i3.p1.3.m3" class="ltx_Math" alttext="x=0" display="inline"><mrow><mi>x</mi><mo>=</mo><mn>0</mn></mrow></math>).</p>
+</div>
+</li>
+<li id="S4.I1.i4" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iv)</span> 
+<div id="S4.I1.i4.p1" class="ltx_para ltx_noindent">
+<p id="S4.I1.i4.p1.2" class="ltx_p"><math id="S4.I1.i4.p1.1.m1" class="ltx_Math" alttext="\mathcal{X}=(-\infty,-1]\cup[1,\infty)" display="inline"><mrow><mi class="ltx_font_mathcaligraphic">𝒳</mi><mo>=</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mo>-</mo><mi mathvariant="normal">∞</mi></mrow><mo>,</mo><mrow><mo>-</mo><mn>1</mn></mrow><mo stretchy="false">]</mo></mrow><mo>∪</mo><mrow><mo stretchy="false">[</mo><mn>1</mn><mo>,</mo><mi mathvariant="normal">∞</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>: This set is non-convex, and we can see that there are two global minima (<math id="S4.I1.i4.p1.2.m2" class="ltx_Math" alttext="x=\pm 1" display="inline"><mrow><mi>x</mi><mo>=</mo><mrow><mo>±</mo><mn>1</mn></mrow></mrow></math>).</p>
+</div>
+</li>
+</ol>
+</div>
+</section>
+<section id="S4.SS8.SSS4" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.8.4 </span>Showing that a function is convex</h4>
+
+<div id="S4.SS8.SSS4.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS4.p1.1" class="ltx_p">Hopefully the previous section has convinced the reader that convexity is an important property.
+Next we turn to the issue of showing that a function is (strictly/strongly) convex.
+It is of course possible (in principle) to directly show that the condition in the definition holds, but this is usually not the easiest way.</p>
+</div>
+<div id="Thmproposition14" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition14.1.1.1" class="ltx_text ltx_font_bold">Proposition 14</span></span><span id="Thmproposition14.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition14.p1" class="ltx_para">
+<p id="Thmproposition14.p1.1" class="ltx_p"><span id="Thmproposition14.p1.1.1" class="ltx_text ltx_font_italic">Norms are convex.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.1" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.1.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.1.p1.4" class="ltx_p">Let <math id="S4.SS8.SSS4.1.p1.1.m1" class="ltx_Math" alttext="\|\cdot\|" display="inline"><mrow><mo>∥</mo><mo>⋅</mo><mo>∥</mo></mrow></math> be a norm on a vector space <math id="S4.SS8.SSS4.1.p1.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>. Then for all <math id="S4.SS8.SSS4.1.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in V" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>V</mi></mrow></math> and <math id="S4.SS8.SSS4.1.p1.4.m4" class="ltx_Math" alttext="t\in[0,1]" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></math>,</p>
+<table id="S4.Ex74" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex74.m1" class="ltx_Math" alttext="\|t\mathbf{x}+(1-t)\mathbf{y}\|\leq\|t\mathbf{x}\|+\|(1-t)\mathbf{y}\|=|t|\|%
+\mathbf{x}\|+|1-t|\|\mathbf{y}\|=t\|\mathbf{x}\|+(1-t)\|\mathbf{y}\|" display="block"><mrow><mrow><mo>∥</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo>∥</mo></mrow><mo>≤</mo><mrow><mrow><mo>∥</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>∥</mo></mrow><mo>+</mo><mrow><mo>∥</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></mrow><mo>=</mo><mrow><mrow><mrow><mo stretchy="false">|</mo><mi>t</mi><mo stretchy="false">|</mo></mrow><mo>⁢</mo><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">|</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">|</mo></mrow><mo>⁢</mo><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow></mrow></mrow><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo>∥</mo><mi>𝐲</mi><mo>∥</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS4.1.p1.7" class="ltx_p">where we have used respectively the triangle inequality, the homogeneity of norms, and the fact that <math id="S4.SS8.SSS4.1.p1.5.m1" class="ltx_Math" alttext="t" display="inline"><mi>t</mi></math> and <math id="S4.SS8.SSS4.1.p1.6.m2" class="ltx_Math" alttext="1-t" display="inline"><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow></math> are nonnegative.
+Hence <math id="S4.SS8.SSS4.1.p1.7.m3" class="ltx_Math" alttext="\|\cdot\|" display="inline"><mrow><mo>∥</mo><mo>⋅</mo><mo>∥</mo></mrow></math> is convex.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition15" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition15.1.1.1" class="ltx_text ltx_font_bold">Proposition 15</span></span><span id="Thmproposition15.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition15.p1" class="ltx_para">
+<p id="Thmproposition15.p1.2" class="ltx_p"><span id="Thmproposition15.p1.2.2" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition15.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is differentiable. Then <math id="Thmproposition15.p1.2.2.m2" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex if and only if</span></p>
+<table id="S4.Ex75" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex75.m1" class="ltx_Math" alttext="f(\mathbf{y})\geq f(\mathbf{x})+\langle\nabla f(\mathbf{x}),\mathbf{y}-\mathbf%
+{x}\rangle" display="block"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≥</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mo stretchy="false">⟨</mo><mrow><mrow><mo>∇</mo><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mi>𝐲</mi><mo>-</mo><mi>𝐱</mi></mrow><mo stretchy="false">⟩</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmproposition15.p1.3" class="ltx_p"><span id="Thmproposition15.p1.3.1" class="ltx_text ltx_font_italic">for all <math id="Thmproposition15.p1.3.1.m1" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}f" display="inline"><mrow><mrow><mi>𝐱</mi><mo mathvariant="normal">,</mo><mi>𝐲</mi></mrow><mo mathvariant="normal">∈</mo><mrow><mo mathvariant="normal">dom</mo><mo mathvariant="italic">⁡</mo><mi>f</mi></mrow></mrow></math>.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.2" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.2.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.2.p1.1" class="ltx_p">To-do.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition16" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition16.1.1.1" class="ltx_text ltx_font_bold">Proposition 16</span></span><span id="Thmproposition16.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition16.p1" class="ltx_para">
+<p id="Thmproposition16.p1.1" class="ltx_p"><span id="Thmproposition16.p1.1.1" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition16.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is twice differentiable.
+Then</span></p>
+<ol id="S4.I2" class="ltx_enumerate">
+<li id="S4.I2.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S4.I2.i1.1.1.1" class="ltx_text">(i)</span></span> 
+<div id="S4.I2.i1.p1" class="ltx_para ltx_noindent">
+<p id="S4.I2.i1.p1.3" class="ltx_p"><math id="S4.I2.i1.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math><span id="S4.I2.i1.p1.3.1" class="ltx_text ltx_font_italic"> is convex if and only if </span><math id="S4.I2.i1.p1.2.m2" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})\succeq 0" display="inline"><mrow><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>⪰</mo><mn>0</mn></mrow></math><span id="S4.I2.i1.p1.3.2" class="ltx_text ltx_font_italic"> for all </span><math id="S4.I2.i1.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}\in\operatorname*{dom}f" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow></mrow></math><span id="S4.I2.i1.p1.3.3" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+<li id="S4.I2.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S4.I2.i2.1.1.1" class="ltx_text">(ii)</span></span> 
+<div id="S4.I2.i2.p1" class="ltx_para ltx_noindent">
+<p id="S4.I2.i2.p1.3" class="ltx_p"><span id="S4.I2.i2.p1.3.1" class="ltx_text ltx_font_italic">If </span><math id="S4.I2.i2.p1.1.m1" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})\succ 0" display="inline"><mrow><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≻</mo><mn>0</mn></mrow></math><span id="S4.I2.i2.p1.3.2" class="ltx_text ltx_font_italic"> for all </span><math id="S4.I2.i2.p1.2.m2" class="ltx_Math" alttext="\mathbf{x}\in\operatorname*{dom}f" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow></mrow></math><span id="S4.I2.i2.p1.3.3" class="ltx_text ltx_font_italic">, then </span><math id="S4.I2.i2.p1.3.m3" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math><span id="S4.I2.i2.p1.3.4" class="ltx_text ltx_font_italic"> is strictly convex.</span></p>
+</div>
+</li>
+<li id="S4.I2.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S4.I2.i3.1.1.1" class="ltx_text">(iii)</span></span> 
+<div id="S4.I2.i3.p1" class="ltx_para ltx_noindent">
+<p id="S4.I2.i3.p1.4" class="ltx_p"><math id="S4.I2.i3.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math><span id="S4.I2.i3.p1.4.1" class="ltx_text ltx_font_italic"> is </span><math id="S4.I2.i3.p1.2.m2" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math><span id="S4.I2.i3.p1.4.2" class="ltx_text ltx_font_italic">-strongly convex if and only if </span><math id="S4.I2.i3.p1.3.m3" class="ltx_Math" alttext="\nabla^{2}f(\mathbf{x})\succeq mI" display="inline"><mrow><mrow><mrow><msup><mo>∇</mo><mn>2</mn></msup><mo>⁡</mo><mi>f</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>⪰</mo><mrow><mi>m</mi><mo>⁢</mo><mi>I</mi></mrow></mrow></math><span id="S4.I2.i3.p1.4.3" class="ltx_text ltx_font_italic"> for all </span><math id="S4.I2.i3.p1.4.m4" class="ltx_Math" alttext="\mathbf{x}\in\operatorname*{dom}f" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow></mrow></math><span id="S4.I2.i3.p1.4.4" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+</ol>
+</div>
+</div>
+<div id="S4.SS8.SSS4.3" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.3.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.3.p1.1" class="ltx_p">Omitted.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition17" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition17.1.1.1" class="ltx_text ltx_font_bold">Proposition 17</span></span><span id="Thmproposition17.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition17.p1" class="ltx_para">
+<p id="Thmproposition17.p1.3" class="ltx_p"><span id="Thmproposition17.p1.3.3" class="ltx_text ltx_font_italic">If <math id="Thmproposition17.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex and <math id="Thmproposition17.p1.2.2.m2" class="ltx_Math" alttext="\alpha\geq 0" display="inline"><mrow><mi>α</mi><mo mathvariant="normal">≥</mo><mn mathvariant="normal">0</mn></mrow></math>, then <math id="Thmproposition17.p1.3.3.m3" class="ltx_Math" alttext="\alpha f" display="inline"><mrow><mi>α</mi><mo mathvariant="italic">⁢</mo><mi>f</mi></mrow></math> is convex.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.4.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.4.p1.3" class="ltx_p">Suppose <math id="S4.SS8.SSS4.4.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex and <math id="S4.SS8.SSS4.4.p1.2.m2" class="ltx_Math" alttext="\alpha\geq 0" display="inline"><mrow><mi>α</mi><mo>≥</mo><mn>0</mn></mrow></math>. Then for all <math id="S4.SS8.SSS4.4.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}(\alpha f)=\operatorname*{dom}f" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow></mrow></math>,</p>
+<table id="Sx1.EGx4" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex76"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex76.m1" class="ltx_Math" alttext="\displaystyle(\alpha f)(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex76.m2" class="ltx_Math" alttext="\displaystyle=\alpha f(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex77"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex77.m1" class="ltx_Math" alttext="\displaystyle\leq\alpha\left(tf(\mathbf{x})+(1-t)f(\mathbf{y})\right)" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mi>α</mi><mo>⁢</mo><mrow><mo>(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex78"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex78.m1" class="ltx_Math" alttext="\displaystyle=t(\alpha f(\mathbf{x}))+(1-t)(\alpha f(\mathbf{y}))" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex79"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex79.m1" class="ltx_Math" alttext="\displaystyle=t(\alpha f)(\mathbf{x})+(1-t)(\alpha f)(\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS8.SSS4.4.p1.4" class="ltx_p">so <math id="S4.SS8.SSS4.4.p1.4.m1" class="ltx_Math" alttext="\alpha f" display="inline"><mrow><mi>α</mi><mo>⁢</mo><mi>f</mi></mrow></math> is convex.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition18" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition18.1.1.1" class="ltx_text ltx_font_bold">Proposition 18</span></span><span id="Thmproposition18.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition18.p1" class="ltx_para">
+<p id="Thmproposition18.p1.9" class="ltx_p"><span id="Thmproposition18.p1.9.9" class="ltx_text ltx_font_italic">If <math id="Thmproposition18.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="Thmproposition18.p1.2.2.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> are convex, then <math id="Thmproposition18.p1.3.3.m3" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">+</mo><mi>g</mi></mrow></math> is convex.
+Furthermore, if <math id="Thmproposition18.p1.4.4.m4" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is strictly convex, then <math id="Thmproposition18.p1.5.5.m5" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">+</mo><mi>g</mi></mrow></math> is strictly convex, and if <math id="Thmproposition18.p1.6.6.m6" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is <math id="Thmproposition18.p1.7.7.m7" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math>-strongly convex, then <math id="Thmproposition18.p1.8.8.m8" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo mathvariant="normal">+</mo><mi>g</mi></mrow></math> is <math id="Thmproposition18.p1.9.9.m9" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math>-strongly convex.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.7" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.5.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS4.5.p1.3" class="ltx_p">Suppose <math id="S4.SS8.SSS4.5.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="S4.SS8.SSS4.5.p1.2.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> are convex. Then for all <math id="S4.SS8.SSS4.5.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}(f+g)=\operatorname*{dom}f\cap%
+\operatorname*{dom}g" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mo>dom</mo><mo>⁡</mo><mi>f</mi></mrow><mo>∩</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>g</mi></mrow></mrow></mrow></math>,</p>
+<table id="Sx1.EGx5" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex80"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex80.m1" class="ltx_Math" alttext="\displaystyle(f+g)(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex80.m2" class="ltx_Math" alttext="\displaystyle=f(t\mathbf{x}+(1-t)\mathbf{y})+g(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex81"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex81.m1" class="ltx_Math" alttext="\displaystyle\leq tf(\mathbf{x})+(1-t)f(\mathbf{y})+g(t\mathbf{x}+(1-t)\mathbf%
+{y})" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><span id="S4.Ex81.m2.1.1.1a" class="ltx_text ltx_markedasmath">convexity of <math id="S4.Ex81.m2.1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math></span></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex82"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex82.m1" class="ltx_Math" alttext="\displaystyle\leq tf(\mathbf{x})+(1-t)f(\mathbf{y})+tg(\mathbf{x})+(1-t)g(%
+\mathbf{y})" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><span id="S4.Ex82.m2.1.1.1a" class="ltx_text ltx_markedasmath">convexity of <math id="S4.Ex82.m2.1.1.1.m1" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math></span></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex83"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex83.m1" class="ltx_Math" alttext="\displaystyle=t(f(\mathbf{x})+g(\mathbf{x}))+(1-t)(f(\mathbf{y})+g(\mathbf{y}))" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex84"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex84.m1" class="ltx_Math" alttext="\displaystyle=t(f+g)(\mathbf{x})+(1-t)(f+g)(\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS8.SSS4.5.p1.4" class="ltx_p">so <math id="S4.SS8.SSS4.5.p1.4.m1" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow></math> is convex.</p>
+</div>
+<div id="S4.SS8.SSS4.6.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS4.6.p2.4" class="ltx_p">If <math id="S4.SS8.SSS4.6.p2.1.m1" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is strictly convex, the second inequality above holds strictly for <math id="S4.SS8.SSS4.6.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}\neq\mathbf{y}" display="inline"><mrow><mi>𝐱</mi><mo>≠</mo><mi>𝐲</mi></mrow></math> and <math id="S4.SS8.SSS4.6.p2.3.m3" class="ltx_Math" alttext="t\in(0,1)" display="inline"><mrow><mi>t</mi><mo>∈</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">)</mo></mrow></mrow></math>, so <math id="S4.SS8.SSS4.6.p2.4.m4" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow></math> is strictly convex.</p>
+</div>
+<div id="S4.SS8.SSS4.7.p3" class="ltx_para">
+<p id="S4.SS8.SSS4.7.p3.4" class="ltx_p">If <math id="S4.SS8.SSS4.7.p3.1.m1" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is <math id="S4.SS8.SSS4.7.p3.2.m2" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math>-strongly convex, then the function <math id="S4.SS8.SSS4.7.p3.3.m3" class="ltx_Math" alttext="h(\mathbf{x})\equiv g(\mathbf{x})-\frac{m}{2}\|\mathbf{x}\|_{2}^{2}" display="inline"><mrow><mrow><mi>h</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≡</mo><mrow><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>-</mo><mrow><mfrac><mi>m</mi><mn>2</mn></mfrac><mo>⁢</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></mrow></mrow></math> is convex, so <math id="S4.SS8.SSS4.7.p3.4.m4" class="ltx_Math" alttext="f+h" display="inline"><mrow><mi>f</mi><mo>+</mo><mi>h</mi></mrow></math> is convex.
+But</p>
+<table id="S4.Ex85" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex85.m1" class="ltx_Math" alttext="(f+h)(\mathbf{x})\equiv f(\mathbf{x})+h(\mathbf{x})\equiv f(\mathbf{x})+g(%
+\mathbf{x})-\frac{m}{2}\|\mathbf{x}\|_{2}^{2}\equiv(f+g)(\mathbf{x})-\frac{m}{%
+2}\|\mathbf{x}\|_{2}^{2}" display="block"><mrow><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>h</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≡</mo><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>h</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>≡</mo><mrow><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>-</mo><mrow><mfrac><mi>m</mi><mn>2</mn></mfrac><mo>⁢</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></mrow><mo>≡</mo><mrow><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>-</mo><mrow><mfrac><mi>m</mi><mn>2</mn></mfrac><mo>⁢</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS8.SSS4.7.p3.6" class="ltx_p">so <math id="S4.SS8.SSS4.7.p3.5.m1" class="ltx_Math" alttext="f+g" display="inline"><mrow><mi>f</mi><mo>+</mo><mi>g</mi></mrow></math> is <math id="S4.SS8.SSS4.7.p3.6.m2" class="ltx_Math" alttext="m" display="inline"><mi>m</mi></math>-strongly convex.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition19" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition19.1.1.1" class="ltx_text ltx_font_bold">Proposition 19</span></span><span id="Thmproposition19.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition19.p1" class="ltx_para">
+<p id="Thmproposition19.p1.2" class="ltx_p"><span id="Thmproposition19.p1.2.2" class="ltx_text ltx_font_italic">If <math id="Thmproposition19.p1.1.1.m1" class="ltx_Math" alttext="f_{1},\dots,f_{n}" display="inline"><mrow><msub><mi>f</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>f</mi><mi>n</mi></msub></mrow></math> are convex and <math id="Thmproposition19.p1.2.2.m2" class="ltx_Math" alttext="\alpha_{1},\dots,\alpha_{n}\geq 0" display="inline"><mrow><mrow><msub><mi>α</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>α</mi><mi>n</mi></msub></mrow><mo mathvariant="normal">≥</mo><mn mathvariant="normal">0</mn></mrow></math>, then</span></p>
+<table id="S4.Ex86" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex86.m1" class="ltx_Math" alttext="\sum_{i=1}^{n}\alpha_{i}f_{i}" display="block"><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>α</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>f</mi><mi>i</mi></msub></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="Thmproposition19.p1.3" class="ltx_p"><span id="Thmproposition19.p1.3.1" class="ltx_text ltx_font_italic">is convex.
+</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.8" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.8.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.8.p1.1" class="ltx_p">Follows from the previous two propositions by induction.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition20" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition20.1.1.1" class="ltx_text ltx_font_bold">Proposition 20</span></span><span id="Thmproposition20.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition20.p1" class="ltx_para">
+<p id="Thmproposition20.p1.4" class="ltx_p"><span id="Thmproposition20.p1.4.4" class="ltx_text ltx_font_italic">If <math id="Thmproposition20.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex, then <math id="Thmproposition20.p1.2.2.m2" class="ltx_Math" alttext="g(\mathbf{x})\equiv f(\mathbf{A}\mathbf{x}+\mathbf{b})" display="inline"><mrow><mrow><mi>g</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>𝐱</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">≡</mo><mrow><mi>f</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mrow><mi>𝐀𝐱</mi><mo mathvariant="normal">+</mo><mi>𝐛</mi></mrow><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></mrow></math> is convex for any appropriately-sized <math id="Thmproposition20.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math> and <math id="Thmproposition20.p1.4.4.m4" class="ltx_Math" alttext="\mathbf{b}" display="inline"><mi>𝐛</mi></math>.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.9" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.9.p1" class="ltx_para">
+<p id="S4.SS8.SSS4.9.p1.3" class="ltx_p">Suppose <math id="S4.SS8.SSS4.9.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> is convex and <math id="S4.SS8.SSS4.9.p1.2.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is defined like so. Then for all <math id="S4.SS8.SSS4.9.p1.3.m3" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}g" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>g</mi></mrow></mrow></math>,</p>
+<table id="Sx1.EGx6" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex87"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex87.m1" class="ltx_Math" alttext="\displaystyle g(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex87.m2" class="ltx_Math" alttext="\displaystyle=f(\mathbf{A}(t\mathbf{x}+(1-t)\mathbf{y})+\mathbf{b})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>𝐀</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex88"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex88.m1" class="ltx_Math" alttext="\displaystyle=f(t\mathbf{A}\mathbf{x}+(1-t)\mathbf{A}\mathbf{y}+\mathbf{b})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐀𝐲</mi></mrow><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex89"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex89.m1" class="ltx_Math" alttext="\displaystyle=f(t\mathbf{A}\mathbf{x}+(1-t)\mathbf{A}\mathbf{y}+t\mathbf{b}+(1%
+-t)\mathbf{b})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐀𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐀𝐲</mi></mrow><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐛</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐛</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex90"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex90.m1" class="ltx_Math" alttext="\displaystyle=f(t(\mathbf{A}\mathbf{x}+\mathbf{b})+(1-t)(\mathbf{A}\mathbf{y}+%
+\mathbf{b}))" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀𝐱</mi><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀𝐲</mi><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+<tbody id="S4.Ex91"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex91.m1" class="ltx_Math" alttext="\displaystyle\leq tf(\mathbf{A}\mathbf{x}+\mathbf{b})+(1-t)f(\mathbf{A}\mathbf%
+{y}+\mathbf{b})" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀𝐱</mi><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐀𝐲</mi><mo>+</mo><mi>𝐛</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><span id="S4.Ex91.m2.1.1.1a" class="ltx_text ltx_markedasmath">convexity of <math id="S4.Ex91.m2.1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math></span></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex92"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex92.m1" class="ltx_Math" alttext="\displaystyle=tg(\mathbf{x})+(1-t)g(\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright" colspan="2"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS8.SSS4.9.p1.4" class="ltx_p">Thus <math id="S4.SS8.SSS4.9.p1.4.m1" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is convex.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition21" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition21.1.1.1" class="ltx_text ltx_font_bold">Proposition 21</span></span><span id="Thmproposition21.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition21.p1" class="ltx_para">
+<p id="Thmproposition21.p1.3" class="ltx_p"><span id="Thmproposition21.p1.3.3" class="ltx_text ltx_font_italic">If <math id="Thmproposition21.p1.1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="Thmproposition21.p1.2.2.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> are convex, then <math id="Thmproposition21.p1.3.3.m3" class="ltx_Math" alttext="h(\mathbf{x})\equiv\max\{f(\mathbf{x}),g(\mathbf{x})\}" display="inline"><mrow><mrow><mi>h</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>𝐱</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">≡</mo><mrow><mi mathvariant="normal">max</mi><mo mathvariant="italic">⁡</mo><mrow><mo mathvariant="normal" stretchy="false">{</mo><mrow><mi>f</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>𝐱</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">,</mo><mrow><mi>g</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>𝐱</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal" stretchy="false">}</mo></mrow></mrow></mrow></math> is convex.</span></p>
+</div>
+</div>
+<div id="S4.SS8.SSS4.11" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS8.SSS4.10.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS4.10.p1.4" class="ltx_p">Suppose <math id="S4.SS8.SSS4.10.p1.1.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="S4.SS8.SSS4.10.p1.2.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> are convex and <math id="S4.SS8.SSS4.10.p1.3.m3" class="ltx_Math" alttext="h" display="inline"><mi>h</mi></math> is defined like so. Then for all <math id="S4.SS8.SSS4.10.p1.4.m4" class="ltx_Math" alttext="\mathbf{x},\mathbf{y}\in\operatorname*{dom}h" display="inline"><mrow><mrow><mi>𝐱</mi><mo>,</mo><mi>𝐲</mi></mrow><mo>∈</mo><mrow><mo>dom</mo><mo>⁡</mo><mi>h</mi></mrow></mrow></math>,</p>
+<table id="Sx1.EGx7" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex93"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex93.m1" class="ltx_Math" alttext="\displaystyle h(t\mathbf{x}+(1-t)\mathbf{y})" display="inline"><mrow><mi>h</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex93.m2" class="ltx_Math" alttext="\displaystyle=\max\{f(t\mathbf{x}+(1-t)\mathbf{y}),g(t\mathbf{x}+(1-t)\mathbf{%
+y})\}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>𝐲</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex94"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex94.m1" class="ltx_Math" alttext="\displaystyle\leq\max\{tf(\mathbf{x})+(1-t)f(\mathbf{y}),tg(\mathbf{x})+(1-t)g%
+(\mathbf{y})\}" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>,</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex95"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex95.m1" class="ltx_Math" alttext="\displaystyle\leq\max\{tf(\mathbf{x}),tg(\mathbf{x})\}+\max\{(1-t)f(\mathbf{y}%
+),(1-t)g(\mathbf{y})\}" display="inline"><mrow><mi></mi><mo>≤</mo><mrow><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mi>t</mi><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mi>t</mi><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow><mo>+</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex96"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex96.m1" class="ltx_Math" alttext="\displaystyle=t\max\{f(\mathbf{x}),g(\mathbf{x})\}+(1-t)\max\{f(\mathbf{y}),g(%
+\mathbf{y})\}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo>,</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex97"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex97.m1" class="ltx_Math" alttext="\displaystyle=th(\mathbf{x})+(1-t)h(\mathbf{y})" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>t</mi><mo>⁢</mo><mi>h</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mn>1</mn><mo>-</mo><mi>t</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>h</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐲</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS8.SSS4.10.p1.9" class="ltx_p">Note that in the first inequality we have used convexity of <math id="S4.SS8.SSS4.10.p1.5.m1" class="ltx_Math" alttext="f" display="inline"><mi>f</mi></math> and <math id="S4.SS8.SSS4.10.p1.6.m2" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> plus the fact that <math id="S4.SS8.SSS4.10.p1.7.m3" class="ltx_Math" alttext="a\leq c,b\leq d" display="inline"><mrow><mrow><mi>a</mi><mo>≤</mo><mi>c</mi></mrow><mo>,</mo><mrow><mi>b</mi><mo>≤</mo><mi>d</mi></mrow></mrow></math> implies <math id="S4.SS8.SSS4.10.p1.8.m4" class="ltx_Math" alttext="\max\{a,b\}\leq\max\{c,d\}" display="inline"><mrow><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo stretchy="false">}</mo></mrow></mrow><mo>≤</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mi>c</mi><mo>,</mo><mi>d</mi><mo stretchy="false">}</mo></mrow></mrow></mrow></math>.
+In the second inequality we have used the fact that <math id="S4.SS8.SSS4.10.p1.9.m5" class="ltx_Math" alttext="\max\{a+b,c+d\}\leq\max\{a,c\}+\max\{b,d\}" display="inline"><mrow><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow><mo>,</mo><mrow><mi>c</mi><mo>+</mo><mi>d</mi></mrow><mo stretchy="false">}</mo></mrow></mrow><mo>≤</mo><mrow><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mi>a</mi><mo>,</mo><mi>c</mi><mo stretchy="false">}</mo></mrow></mrow><mo>+</mo><mrow><mi>max</mi><mo>⁡</mo><mrow><mo stretchy="false">{</mo><mi>b</mi><mo>,</mo><mi>d</mi><mo stretchy="false">}</mo></mrow></mrow></mrow></mrow></math>.</p>
+</div>
+<div id="S4.SS8.SSS4.11.p2" class="ltx_para">
+<p id="S4.SS8.SSS4.11.p2.1" class="ltx_p">Thus <math id="S4.SS8.SSS4.11.p2.1.m1" class="ltx_Math" alttext="h" display="inline"><mi>h</mi></math> is convex.
+∎</p>
+</div>
+</div>
+</section>
+<section id="S4.SS8.SSS5" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">4.8.5 </span>Examples</h4>
+
+<div id="S4.SS8.SSS5.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS5.p1.1" class="ltx_p">A good way to gain intuition about the distinction between convex, strictly convex, and strongly convex functions is to consider examples where the stronger property fails to hold.</p>
+</div>
+<div id="S4.SS8.SSS5.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS5.p2.1" class="ltx_p">Functions that are convex but not strictly convex:</p>
+<ol id="S4.I3" class="ltx_enumerate">
+<li id="S4.I3.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S4.I3.i1.p1" class="ltx_para ltx_noindent">
+<p id="S4.I3.i1.p1.2" class="ltx_p"><math id="S4.I3.i1.p1.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\mathbf{w}^{\!\top\!}\mathbf{x}+\alpha" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><msup><mi>𝐰</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo>+</mo><mi>α</mi></mrow></mrow></math> for any <math id="S4.I3.i1.p1.2.m2" class="ltx_Math" alttext="\mathbf{w}\in\mathbb{R}^{d},\alpha\in\mathbb{R}" display="inline"><mrow><mrow><mi>𝐰</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow><mo>,</mo><mrow><mi>α</mi><mo>∈</mo><mi>ℝ</mi></mrow></mrow></math>.
+Such a function is called an <span id="S4.I3.i1.p1.2.1" class="ltx_text ltx_font_bold">affine function</span>, and it is both convex and concave.
+(In fact, a function is affine if and only if it is both convex and concave.)
+Note that linear functions and constant functions are special cases of affine functions.</p>
+</div>
+</li>
+<li id="S4.I3.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S4.I3.i2.p1" class="ltx_para ltx_noindent">
+<p id="S4.I3.i2.p1.1" class="ltx_p"><math id="S4.I3.i2.p1.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\|\mathbf{x}\|_{1}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msub><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>1</mn></msub></mrow></math></p>
+</div>
+</li>
+</ol>
+</div>
+<div id="S4.SS8.SSS5.p3" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS5.p3.1" class="ltx_p">Functions that are strictly but not strongly convex:</p>
+<ol id="S4.I4" class="ltx_enumerate">
+<li id="S4.I4.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S4.I4.i1.p1" class="ltx_para ltx_noindent">
+<p id="S4.I4.i1.p1.2" class="ltx_p"><math id="S4.I4.i1.p1.1.m1" class="ltx_Math" alttext="f(x)=x^{4}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msup><mi>x</mi><mn>4</mn></msup></mrow></math>.
+This example is interesting because it is strictly convex but you cannot show this fact via a second-order argument (since <math id="S4.I4.i1.p1.2.m2" class="ltx_Math" alttext="f^{\prime\prime}(0)=0" display="inline"><mrow><mrow><msup><mi>f</mi><mo>′′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math>).</p>
+</div>
+</li>
+<li id="S4.I4.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S4.I4.i2.p1" class="ltx_para ltx_noindent">
+<p id="S4.I4.i2.p1.1" class="ltx_p"><math id="S4.I4.i2.p1.1.m1" class="ltx_Math" alttext="f(x)=\exp(x)" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>exp</mi><mo>⁡</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></mrow></math>.
+This example is interesting because it’s bounded below but has no local minimum.</p>
+</div>
+</li>
+<li id="S4.I4.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(iii)</span> 
+<div id="S4.I4.i3.p1" class="ltx_para ltx_noindent">
+<p id="S4.I4.i3.p1.1" class="ltx_p"><math id="S4.I4.i3.p1.1.m1" class="ltx_Math" alttext="f(x)=-\log x" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo>-</mo><mrow><mi>log</mi><mo>⁡</mo><mi>x</mi></mrow></mrow></mrow></math>.
+This example is interesting because it’s strictly convex but not bounded below.</p>
+</div>
+</li>
+</ol>
+</div>
+<div id="S4.SS8.SSS5.p4" class="ltx_para ltx_noindent">
+<p id="S4.SS8.SSS5.p4.1" class="ltx_p">Functions that are strongly convex:</p>
+<ol id="S4.I5" class="ltx_enumerate">
+<li id="S4.I5.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S4.I5.i1.p1" class="ltx_para ltx_noindent">
+<p id="S4.I5.i1.p1.1" class="ltx_p"><math id="S4.I5.i1.p1.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\|\mathbf{x}\|_{2}^{2}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><msubsup><mrow><mo>∥</mo><mi>𝐱</mi><mo>∥</mo></mrow><mn>2</mn><mn>2</mn></msubsup></mrow></math></p>
+</div>
+</li>
+</ol>
+</div>
+</section>
+</section>
+<section id="S4.SS9" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">4.9 </span>Orthogonal projections</h3>
+
+<div id="S4.SS9.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS9.p1.5" class="ltx_p">We now consider a particular kind of optimization problem that is particularly well-understood and can often be solved in closed form: given some point <math id="S4.SS9.p1.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> in an inner product space <math id="S4.SS9.p1.2.m2" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>, find the closest point to <math id="S4.SS9.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> in a subspace <math id="S4.SS9.p1.4.m4" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> of <math id="S4.SS9.p1.5.m5" class="ltx_Math" alttext="V" display="inline"><mi>V</mi></math>.
+This process is referred to as <span id="S4.SS9.p1.5.1" class="ltx_text ltx_font_bold">projection onto a subspace</span>.</p>
+</div>
+<div id="S4.SS9.p2" class="ltx_para ltx_noindent">
+<p id="S4.SS9.p2.14" class="ltx_p">The following diagram should make it geometrically clear that, at least in Euclidean space, the solution is intimately related to orthogonality and the Pythagorean theorem:</p>
+<img src="orthogonal-projection.png" id="S4.SS9.p2.g1" class="ltx_graphics ltx_centering ltx_img_square" width="299" height="316" alt="">
+<p id="S4.SS9.p2.13" class="ltx_p">Here <math id="S4.SS9.p2.1.m1" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> is an arbitrary element of the subspace <math id="S4.SS9.p2.2.m2" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>, and <math id="S4.SS9.p2.3.m3" class="ltx_Math" alttext="\mathbf{y}^{*}" display="inline"><msup><mi>𝐲</mi><mo>*</mo></msup></math> is the point in <math id="S4.SS9.p2.4.m4" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> such that <math id="S4.SS9.p2.5.m5" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}" display="inline"><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow></math> is perpendicular to <math id="S4.SS9.p2.6.m6" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>.
+The hypotenuse of a right triangle (in this case <math id="S4.SS9.p2.7.m7" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}\|" display="inline"><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></math>) is always longer than either of the legs (in this case <math id="S4.SS9.p2.8.m8" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}^{*}\|" display="inline"><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>∥</mo></mrow></math> and <math id="S4.SS9.p2.9.m9" class="ltx_Math" alttext="\|\mathbf{y}^{*}-\mathbf{y}\|" display="inline"><mrow><mo>∥</mo><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></math>), and when <math id="S4.SS9.p2.10.m10" class="ltx_Math" alttext="\mathbf{y}\neq\mathbf{y}^{*}" display="inline"><mrow><mi>𝐲</mi><mo>≠</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow></math> there always exists such a triangle between <math id="S4.SS9.p2.11.m11" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>, <math id="S4.SS9.p2.12.m12" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math>, and <math id="S4.SS9.p2.13.m13" class="ltx_Math" alttext="\mathbf{y}^{*}" display="inline"><msup><mi>𝐲</mi><mo>*</mo></msup></math>.</p>
+</div>
+<div id="S4.SS9.p3" class="ltx_para">
+<p id="S4.SS9.p3.2" class="ltx_p">Our intuition from Euclidean space suggests that the closest point to <math id="S4.SS9.p3.1.m1" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> in <math id="S4.SS9.p3.2.m2" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> has the perpendicularity property described above, and we now show that this is indeed the case.</p>
+</div>
+<div id="Thmproposition22" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition22.1.1.1" class="ltx_text ltx_font_bold">Proposition 22</span></span><span id="Thmproposition22.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition22.p1" class="ltx_para">
+<p id="Thmproposition22.p1.6" class="ltx_p"><span id="Thmproposition22.p1.6.6" class="ltx_text ltx_font_italic">Suppose <math id="Thmproposition22.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo mathvariant="normal">∈</mo><mi>V</mi></mrow></math> and <math id="Thmproposition22.p1.2.2.m2" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo mathvariant="normal">∈</mo><mi>S</mi></mrow></math>.
+Then <math id="Thmproposition22.p1.3.3.m3" class="ltx_Math" alttext="\mathbf{y}^{*}" display="inline"><msup><mi>𝐲</mi><mo mathvariant="normal">*</mo></msup></math> is the unique minimizer of <math id="Thmproposition22.p1.4.4.m4" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}\|" display="inline"><mrow><mo mathvariant="normal">∥</mo><mrow><mi>𝐱</mi><mo mathvariant="normal">-</mo><mi>𝐲</mi></mrow><mo mathvariant="normal">∥</mo></mrow></math> over <math id="Thmproposition22.p1.5.5.m5" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo mathvariant="normal">∈</mo><mi>S</mi></mrow></math> if and only if <math id="Thmproposition22.p1.6.6.m6" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}\perp S" display="inline"><mrow><mrow><mi>𝐱</mi><mo mathvariant="normal">-</mo><msup><mi>𝐲</mi><mo mathvariant="normal">*</mo></msup></mrow><mo mathvariant="normal">⟂</mo><mi>S</mi></mrow></math>.</span></p>
+</div>
+</div>
+<div id="S4.SS9.2" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS9.1.p1" class="ltx_para ltx_noindent">
+<p id="S4.SS9.1.p1.8" class="ltx_p"><math id="S4.SS9.1.p1.1.m1" class="ltx_Math" alttext="(\implies)" display="inline"><mrow><mo stretchy="false">(</mo><mo>⟹</mo><mo stretchy="false">)</mo></mrow></math>
+Suppose <math id="S4.SS9.1.p1.2.m2" class="ltx_Math" alttext="\mathbf{y}^{*}" display="inline"><msup><mi>𝐲</mi><mo>*</mo></msup></math> is the unique minimizer of <math id="S4.SS9.1.p1.3.m3" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}\|" display="inline"><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></math> over <math id="S4.SS9.1.p1.4.m4" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></math>.
+That is, <math id="S4.SS9.1.p1.5.m5" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}^{*}\|\leq\|\mathbf{x}-\mathbf{y}\|" display="inline"><mrow><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>∥</mo></mrow><mo>≤</mo><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></mrow></math> for all <math id="S4.SS9.1.p1.6.m6" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></math>, with equality only if <math id="S4.SS9.1.p1.7.m7" class="ltx_Math" alttext="\mathbf{y}=\mathbf{y}^{*}" display="inline"><mrow><mi>𝐲</mi><mo>=</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow></math>.
+Fix <math id="S4.SS9.1.p1.8.m8" class="ltx_Math" alttext="\mathbf{v}\in S" display="inline"><mrow><mi>𝐯</mi><mo>∈</mo><mi>S</mi></mrow></math> and observe that
+</p>
+<table id="Sx1.EGx8" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex98"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex98.m1" class="ltx_Math" alttext="\displaystyle g(t)" display="inline"><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>t</mi><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex98.m2" class="ltx_Math" alttext="\displaystyle\mathrel{\mathop{:}}=\|\mathbf{x}-\mathbf{y}^{*}+t\mathbf{v}\|^{2}" display="inline"><mrow><mo movablelimits="false">:</mo><mo>=</mo><mo>∥</mo><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup><mo>+</mo><mi>t</mi><mi>𝐯</mi><msup><mo>∥</mo><mn>2</mn></msup></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex99"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex99.m1" class="ltx_Math" alttext="\displaystyle=\langle\mathbf{x}-\mathbf{y}^{*}+t\mathbf{v},\mathbf{x}-\mathbf{%
+y}^{*}+t\mathbf{v}\rangle" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mo stretchy="false">⟨</mo><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐯</mi></mrow></mrow><mo>,</mo><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>+</mo><mrow><mi>t</mi><mo>⁢</mo><mi>𝐯</mi></mrow></mrow><mo stretchy="false">⟩</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex100"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex100.m1" class="ltx_Math" alttext="\displaystyle=\langle\mathbf{x}-\mathbf{y}^{*},\mathbf{x}-\mathbf{y}^{*}%
+\rangle-2t\langle\mathbf{x}-\mathbf{y}^{*},\mathbf{v}\rangle+t^{2}\langle%
+\mathbf{v},\mathbf{v}\rangle" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>,</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo stretchy="false">⟩</mo></mrow><mo>-</mo><mrow><mn>2</mn><mo>⁢</mo><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>,</mo><mi>𝐯</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow><mo>+</mo><mrow><msup><mi>t</mi><mn>2</mn></msup><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐯</mi><mo>,</mo><mi>𝐯</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex101"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex101.m1" class="ltx_Math" alttext="\displaystyle=\|\mathbf{x}-\mathbf{y}^{*}\|^{2}-2t\langle\mathbf{x}-\mathbf{y}%
+^{*},\mathbf{v}\rangle+t^{2}\|\mathbf{v}\|^{2}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><msup><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>∥</mo></mrow><mn>2</mn></msup><mo>-</mo><mrow><mn>2</mn><mo>⁢</mo><mi>t</mi><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>,</mo><mi>𝐯</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow><mo>+</mo><mrow><msup><mi>t</mi><mn>2</mn></msup><mo>⁢</mo><msup><mrow><mo>∥</mo><mi>𝐯</mi><mo>∥</mo></mrow><mn>2</mn></msup></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS9.1.p1.9" class="ltx_p">must have a minimum at <math id="S4.SS9.1.p1.9.m1" class="ltx_Math" alttext="t=0" display="inline"><mrow><mi>t</mi><mo>=</mo><mn>0</mn></mrow></math> as a consequence of this assumption.
+Thus</p>
+<table id="S4.Ex102" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex102.m1" class="ltx_Math" alttext="0=g^{\prime}(0)=\left.-2\langle\mathbf{x}-\mathbf{y}^{*},\mathbf{v}\rangle+2t%
+\|\mathbf{v}\|^{2}\right|_{t=0}=-2\langle\mathbf{x}-\mathbf{y}^{*},\mathbf{v}\rangle" display="block"><mrow><mn>0</mn><mo>=</mo><mrow><msup><mi>g</mi><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mn>0</mn><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mo>-</mo><mrow><mn>2</mn><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>,</mo><mi>𝐯</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow><mo>+</mo><msub><mrow><mrow><mn>2</mn><mo>⁢</mo><mi>t</mi><mo>⁢</mo><msup><mrow><mo>∥</mo><mi>𝐯</mi><mo>∥</mo></mrow><mn>2</mn></msup></mrow><mo fence="true">|</mo></mrow><mrow><mi>t</mi><mo>=</mo><mn>0</mn></mrow></msub></mrow><mo>=</mo><mrow><mo>-</mo><mrow><mn>2</mn><mo>⁢</mo><mrow><mo stretchy="false">⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>,</mo><mi>𝐯</mi><mo stretchy="false">⟩</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS9.1.p1.13" class="ltx_p">giving <math id="S4.SS9.1.p1.10.m1" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}\perp\mathbf{v}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>⟂</mo><mi>𝐯</mi></mrow></math>.
+Since <math id="S4.SS9.1.p1.11.m2" class="ltx_Math" alttext="\mathbf{v}" display="inline"><mi>𝐯</mi></math> was arbitrary in <math id="S4.SS9.1.p1.12.m3" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>, we have <math id="S4.SS9.1.p1.13.m4" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}\perp S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>⟂</mo><mi>S</mi></mrow></math> as claimed.</p>
+</div>
+<div id="S4.SS9.2.p2" class="ltx_para">
+<p id="S4.SS9.2.p2.7" class="ltx_p"><math id="S4.SS9.2.p2.1.m1" class="ltx_Math" alttext="(\impliedby)" display="inline"><mrow><mo stretchy="false">(</mo><mo>⟸</mo><mo stretchy="false">)</mo></mrow></math>
+Suppose <math id="S4.SS9.2.p2.2.m2" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}\perp S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>⟂</mo><mi>S</mi></mrow></math>.
+Observe that for any <math id="S4.SS9.2.p2.3.m3" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></math>, <math id="S4.SS9.2.p2.4.m4" class="ltx_Math" alttext="\mathbf{y}^{*}-\mathbf{y}\in S" display="inline"><mrow><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>-</mo><mi>𝐲</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math> because <math id="S4.SS9.2.p2.5.m5" class="ltx_Math" alttext="\mathbf{y}^{*}\in S" display="inline"><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>∈</mo><mi>S</mi></mrow></math> and <math id="S4.SS9.2.p2.6.m6" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> is closed under subtraction.
+Under the hypothesis, <math id="S4.SS9.2.p2.7.m7" class="ltx_Math" alttext="\mathbf{x}-\mathbf{y}^{*}\perp\mathbf{y}^{*}-\mathbf{y}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>⟂</mo><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>-</mo><mi>𝐲</mi></mrow></mrow></math>, so by the Pythagorean theorem,</p>
+<table id="S4.Ex103" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex103.m1" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}\|=\|\mathbf{x}-\mathbf{y}^{*}+\mathbf{y}^{*}-\mathbf{y%
+}\|=\|\mathbf{x}-\mathbf{y}^{*}\|+\|\mathbf{y}^{*}-\mathbf{y}\|\geq\|\mathbf{x%
+}-\mathbf{y}^{*}\|" display="block"><mrow><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mo>=</mo><mrow><mo>∥</mo><mrow><mrow><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>+</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mo>=</mo><mrow><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>∥</mo></mrow><mo>+</mo><mrow><mo>∥</mo><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></mrow><mo>≥</mo><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow><mo>∥</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS9.2.p2.12" class="ltx_p">and in fact the inequality is strict when <math id="S4.SS9.2.p2.8.m1" class="ltx_Math" alttext="\mathbf{y}\neq\mathbf{y}^{*}" display="inline"><mrow><mi>𝐲</mi><mo>≠</mo><msup><mi>𝐲</mi><mo>*</mo></msup></mrow></math> since this implies <math id="S4.SS9.2.p2.9.m2" class="ltx_Math" alttext="\|\mathbf{y}^{*}-\mathbf{y}\|&gt;0" display="inline"><mrow><mrow><mo>∥</mo><mrow><msup><mi>𝐲</mi><mo>*</mo></msup><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow><mo>&gt;</mo><mn>0</mn></mrow></math>.
+Thus <math id="S4.SS9.2.p2.10.m3" class="ltx_Math" alttext="\mathbf{y}^{*}" display="inline"><msup><mi>𝐲</mi><mo>*</mo></msup></math> is the unique minimizer of <math id="S4.SS9.2.p2.11.m4" class="ltx_Math" alttext="\|\mathbf{x}-\mathbf{y}\|" display="inline"><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></math> over <math id="S4.SS9.2.p2.12.m5" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></math>.
+∎</p>
+</div>
+</div>
+<div id="S4.SS9.p4" class="ltx_para ltx_noindent">
+<p id="S4.SS9.p4.2" class="ltx_p">Since a unique minimizer in <math id="S4.SS9.p4.1.m1" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> can be found for any <math id="S4.SS9.p4.2.m2" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>, we can define an operator</p>
+<table id="S4.Ex104" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex104.m1" class="ltx_Math" alttext="P\mathbf{x}=\operatorname*{arg\,min}_{\mathbf{y}\in S}\|\mathbf{x}-\mathbf{y}\|" display="block"><mrow><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><munder><mrow><mpadded width="+1.7pt"><mi>arg</mi></mpadded><mo movablelimits="false">⁢</mo><mi>min</mi></mrow><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></munder><mo>⁡</mo><mrow><mo>∥</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝐲</mi></mrow><mo>∥</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S4.SS9.p4.12" class="ltx_p">Observe that <math id="S4.SS9.p4.3.m1" class="ltx_Math" alttext="P\mathbf{y}=\mathbf{y}" display="inline"><mrow><mrow><mi>P</mi><mo>⁢</mo><mi>𝐲</mi></mrow><mo>=</mo><mi>𝐲</mi></mrow></math> for any <math id="S4.SS9.p4.4.m2" class="ltx_Math" alttext="\mathbf{y}\in S" display="inline"><mrow><mi>𝐲</mi><mo>∈</mo><mi>S</mi></mrow></math>, since <math id="S4.SS9.p4.5.m3" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math> has distance zero from itself and every other point in <math id="S4.SS9.p4.6.m4" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math> has positive distance from <math id="S4.SS9.p4.7.m5" class="ltx_Math" alttext="\mathbf{y}" display="inline"><mi>𝐲</mi></math>.
+Thus <math id="S4.SS9.p4.8.m6" class="ltx_Math" alttext="P(P\mathbf{x})=P\mathbf{x}" display="inline"><mrow><mrow><mi>P</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow></mrow></math> for any <math id="S4.SS9.p4.9.m7" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math> (i.e., <math id="S4.SS9.p4.10.m8" class="ltx_Math" alttext="P^{2}=P" display="inline"><mrow><msup><mi>P</mi><mn>2</mn></msup><mo>=</mo><mi>P</mi></mrow></math>) because <math id="S4.SS9.p4.11.m9" class="ltx_Math" alttext="P\mathbf{x}\in S" display="inline"><mrow><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>∈</mo><mi>S</mi></mrow></math>.
+The identity <math id="S4.SS9.p4.12.m10" class="ltx_Math" alttext="P^{2}=P" display="inline"><mrow><msup><mi>P</mi><mn>2</mn></msup><mo>=</mo><mi>P</mi></mrow></math> is actually one of the defining properties of a <span id="S4.SS9.p4.12.1" class="ltx_text ltx_font_bold">projection</span>, the other being linearity.
+</p>
+</div>
+<div id="S4.SS9.p5" class="ltx_para ltx_noindent">
+<p id="S4.SS9.p5.5" class="ltx_p">An immediate consequence of the previous result is that <math id="S4.SS9.p5.1.m1" class="ltx_Math" alttext="\mathbf{x}-P\mathbf{x}\perp S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow></mrow><mo>⟂</mo><mi>S</mi></mrow></math> for any <math id="S4.SS9.p5.2.m2" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>, and conversely that <math id="S4.SS9.p5.3.m3" class="ltx_Math" alttext="P" display="inline"><mi>P</mi></math> is the unique operator that satisfies this property for all <math id="S4.SS9.p5.4.m4" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>.
+For this reason, <math id="S4.SS9.p5.5.m5" class="ltx_Math" alttext="P" display="inline"><mi>P</mi></math> is known as an <span id="S4.SS9.p5.5.1" class="ltx_text ltx_font_bold">orthogonal projection</span>.</p>
+</div>
+<div id="S4.SS9.p6" class="ltx_para">
+<p id="S4.SS9.p6.2" class="ltx_p">If we choose an orthonormal basis for the target subspace <math id="S4.SS9.p6.1.m1" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>, it is possible to write down a more specific expression for <math id="S4.SS9.p6.2.m2" class="ltx_Math" alttext="P" display="inline"><mi>P</mi></math>.</p>
+</div>
+<div id="Thmproposition23" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition23.1.1.1" class="ltx_text ltx_font_bold">Proposition 23</span></span><span id="Thmproposition23.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition23.p1" class="ltx_para">
+<p id="Thmproposition23.p1.2" class="ltx_p"><span id="Thmproposition23.p1.2.2" class="ltx_text ltx_font_italic">If <math id="Thmproposition23.p1.1.1.m1" class="ltx_Math" alttext="\mathbf{e}_{1},\dots,\mathbf{e}_{m}" display="inline"><mrow><msub><mi>𝐞</mi><mn mathvariant="normal">1</mn></msub><mo mathvariant="normal">,</mo><mi mathvariant="normal">…</mi><mo mathvariant="normal">,</mo><msub><mi>𝐞</mi><mi>m</mi></msub></mrow></math> is an orthonormal basis for <math id="Thmproposition23.p1.2.2.m2" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>, then</span></p>
+<table id="S4.Ex105" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S4.Ex105.m1" class="ltx_Math" alttext="P\mathbf{x}=\sum_{i=1}^{m}\langle\mathbf{x},\mathbf{e}_{i}\rangle\mathbf{e}_{i}" display="block"><mrow><mrow><mi>P</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>m</mi></munderover><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo stretchy="false">⟩</mo></mrow><mo>⁢</mo><msub><mi>𝐞</mi><mi>i</mi></msub></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S4.SS9.3" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S4.SS9.3.p1" class="ltx_para">
+<p id="S4.SS9.3.p1.4" class="ltx_p">Let <math id="S4.SS9.3.p1.1.m1" class="ltx_Math" alttext="\mathbf{e}_{1},\dots,\mathbf{e}_{m}" display="inline"><mrow><msub><mi>𝐞</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>𝐞</mi><mi>m</mi></msub></mrow></math> be an orthonormal basis for <math id="S4.SS9.3.p1.2.m2" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>, and suppose <math id="S4.SS9.3.p1.3.m3" class="ltx_Math" alttext="\mathbf{x}\in V" display="inline"><mrow><mi>𝐱</mi><mo>∈</mo><mi>V</mi></mrow></math>.
+Then for all <math id="S4.SS9.3.p1.4.m4" class="ltx_Math" alttext="j=1,\dots,m" display="inline"><mrow><mi>j</mi><mo>=</mo><mrow><mn>1</mn><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><mi>m</mi></mrow></mrow></math>,</p>
+<table id="Sx1.EGx9" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S4.Ex106"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S4.Ex106.m1" class="ltx_Math" alttext="\displaystyle\left\langle\mathbf{x}-\sum_{i=1}^{m}\langle\mathbf{x},\mathbf{e}%
+_{i}\rangle\mathbf{e}_{i},\mathbf{e}_{j}\right\rangle" display="inline"><mrow><mo>⟨</mo><mrow><mi>𝐱</mi><mo>-</mo><mrow><mstyle displaystyle="true"><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>m</mi></munderover></mstyle><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo stretchy="false">⟩</mo></mrow><mo>⁢</mo><msub><mi>𝐞</mi><mi>i</mi></msub></mrow></mrow></mrow><mo>,</mo><msub><mi>𝐞</mi><mi>j</mi></msub><mo>⟩</mo></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex106.m2" class="ltx_Math" alttext="\displaystyle=\langle\mathbf{x},\mathbf{e}_{j}\rangle-\sum_{i=1}^{m}\langle%
+\mathbf{x},\mathbf{e}_{i}\rangle\underbrace{\langle\mathbf{e}_{i},\mathbf{e}_{%
+j}\rangle}_{\delta_{ij}}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>j</mi></msub><mo stretchy="false">⟩</mo></mrow><mo>-</mo><mrow><mstyle displaystyle="true"><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>m</mi></munderover></mstyle><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo stretchy="false">⟩</mo></mrow><mo>⁢</mo><munder><munder accentunder="true"><mrow><mo movablelimits="false" stretchy="false">⟨</mo><msub><mi>𝐞</mi><mi>i</mi></msub><mo movablelimits="false">,</mo><msub><mi>𝐞</mi><mi>j</mi></msub><mo movablelimits="false" stretchy="false">⟩</mo></mrow><mo movablelimits="false">⏟</mo></munder><msub><mi>δ</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub></munder></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex107"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex107.m1" class="ltx_Math" alttext="\displaystyle=\langle\mathbf{x},\mathbf{e}_{j}\rangle-\langle\mathbf{x},%
+\mathbf{e}_{j}\rangle" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>j</mi></msub><mo stretchy="false">⟩</mo></mrow><mo>-</mo><mrow><mo stretchy="false">⟨</mo><mi>𝐱</mi><mo>,</mo><msub><mi>𝐞</mi><mi>j</mi></msub><mo stretchy="false">⟩</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S4.Ex108"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S4.Ex108.m1" class="ltx_Math" alttext="\displaystyle=0" display="inline"><mrow><mi></mi><mo>=</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S4.SS9.3.p1.10" class="ltx_p">We have shown that the claimed expression, call it <math id="S4.SS9.3.p1.5.m1" class="ltx_Math" alttext="\tilde{P}\mathbf{x}" display="inline"><mrow><mover accent="true"><mi>P</mi><mo stretchy="false">~</mo></mover><mo>⁢</mo><mi>𝐱</mi></mrow></math>, satisfies <math id="S4.SS9.3.p1.6.m2" class="ltx_Math" alttext="\mathbf{x}-\tilde{P}\mathbf{x}\perp\mathbf{e}_{j}" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><mrow><mover accent="true"><mi>P</mi><mo stretchy="false">~</mo></mover><mo>⁢</mo><mi>𝐱</mi></mrow></mrow><mo>⟂</mo><msub><mi>𝐞</mi><mi>j</mi></msub></mrow></math> for every element <math id="S4.SS9.3.p1.7.m3" class="ltx_Math" alttext="\mathbf{e}_{j}" display="inline"><msub><mi>𝐞</mi><mi>j</mi></msub></math> of the orthonormal basis for <math id="S4.SS9.3.p1.8.m4" class="ltx_Math" alttext="S" display="inline"><mi>S</mi></math>.
+It follows (by linearity of the inner product) that <math id="S4.SS9.3.p1.9.m5" class="ltx_Math" alttext="\mathbf{x}-\tilde{P}\mathbf{x}\perp S" display="inline"><mrow><mrow><mi>𝐱</mi><mo>-</mo><mrow><mover accent="true"><mi>P</mi><mo stretchy="false">~</mo></mover><mo>⁢</mo><mi>𝐱</mi></mrow></mrow><mo>⟂</mo><mi>S</mi></mrow></math>, so the previous result implies <math id="S4.SS9.3.p1.10.m6" class="ltx_Math" alttext="P=\tilde{P}" display="inline"><mrow><mi>P</mi><mo>=</mo><mover accent="true"><mi>P</mi><mo stretchy="false">~</mo></mover></mrow></math>.
+∎</p>
+</div>
+</div>
+<div id="S4.SS9.p7" class="ltx_para ltx_noindent">
+<p id="S4.SS9.p7.2" class="ltx_p">The fact that <math id="S4.SS9.p7.1.m1" class="ltx_Math" alttext="P" display="inline"><mi>P</mi></math> is a linear operator (and thus a proper projection, as earlier we showed <math id="S4.SS9.p7.2.m2" class="ltx_Math" alttext="P^{2}=P" display="inline"><mrow><msup><mi>P</mi><mn>2</mn></msup><mo>=</mo><mi>P</mi></mrow></math>) follows readily from this result.</p>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+</section>
+</section>
+<section id="S5" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">
+<span class="ltx_tag ltx_tag_section">5 </span>Probability</h2>
+
+<div id="S5.p1" class="ltx_para ltx_noindent">
+<p id="S5.p1.1" class="ltx_p">Probability theory provides powerful tools for modeling and dealing with uncertainty.</p>
+</div>
+<section id="S5.SS1" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.1 </span>Basics</h3>
+
+<div id="S5.SS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS1.p1.1" class="ltx_p">Suppose we have some sort of randomized experiment (e.g. a coin toss, die roll) that has a fixed set of possible outcomes.
+This set is called the <span id="S5.SS1.p1.1.1" class="ltx_text ltx_font_bold">sample space</span> and denoted <math id="S5.SS1.p1.1.m1" class="ltx_Math" alttext="\Omega" display="inline"><mi mathvariant="normal">Ω</mi></math>.</p>
+</div>
+<div id="S5.SS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS1.p2.4" class="ltx_p">We would like to define probabilities for some <span id="S5.SS1.p2.4.1" class="ltx_text ltx_font_bold">events</span>, which are subsets of <math id="S5.SS1.p2.1.m1" class="ltx_Math" alttext="\Omega" display="inline"><mi mathvariant="normal">Ω</mi></math>.
+The set of events is denoted <math id="S5.SS1.p2.2.m2" class="ltx_Math" alttext="\mathcal{F}" display="inline"><mi class="ltx_font_mathcaligraphic">ℱ</mi></math>.<span id="footnote7" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">7</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">7</sup><span class="ltx_tag ltx_tag_note">7</span>
+<math id="footnote7.m1" class="ltx_Math" alttext="\mathcal{F}" display="inline"><mi class="ltx_font_mathcaligraphic">ℱ</mi></math> is required to be a <math id="footnote7.m2" class="ltx_Math" alttext="\sigma" display="inline"><mi>σ</mi></math>-algebra for technical reasons; see <cite class="ltx_cite ltx_citemacro_cite">[<a href="#bib.bib5" title="A first look at rigorous probability theory (second edition)" class="ltx_ref">3</a>]</cite>.
+</span></span></span>
+The <span id="S5.SS1.p2.4.2" class="ltx_text ltx_font_bold">complement</span> of the event <math id="S5.SS1.p2.3.m3" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> is another event, <math id="S5.SS1.p2.4.m4" class="ltx_Math" alttext="A^{\text{c}}=\Omega\setminus A" display="inline"><mrow><msup><mi>A</mi><mtext>c</mtext></msup><mo>=</mo><mrow><mi mathvariant="normal">Ω</mi><mo>∖</mo><mi>A</mi></mrow></mrow></math>.</p>
+</div>
+<div id="S5.SS1.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS1.p3.1" class="ltx_p">Then we can define a <span id="S5.SS1.p3.1.1" class="ltx_text ltx_font_bold">probability measure</span> <math id="S5.SS1.p3.1.m1" class="ltx_Math" alttext="\mathbb{P}\mathrel{\mathop{:}}\mathcal{F}\to[0,1]" display="inline"><mrow><mi>ℙ</mi><mo>:</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi><mo>→</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></math> which must satisfy</p>
+<ol id="S5.I1" class="ltx_enumerate">
+<li id="S5.I1.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(i)</span> 
+<div id="S5.I1.i1.p1" class="ltx_para ltx_noindent">
+<p id="S5.I1.i1.p1.1" class="ltx_p"><math id="S5.I1.i1.p1.1.m1" class="ltx_Math" alttext="\mathbb{P}(\Omega)=1" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math></p>
+</div>
+</li>
+<li id="S5.I1.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item">(ii)</span> 
+<div id="S5.I1.i2.p1" class="ltx_para ltx_noindent">
+<p id="S5.I1.i2.p1.1" class="ltx_p"><span id="S5.I1.i2.p1.1.1" class="ltx_text ltx_font_bold">Countable additivity</span>: for any countable collection of disjoint sets <math id="S5.I1.i2.p1.1.m1" class="ltx_Math" alttext="\{A_{i}\}\subseteq\mathcal{F}" display="inline"><mrow><mrow><mo stretchy="false">{</mo><msub><mi>A</mi><mi>i</mi></msub><mo stretchy="false">}</mo></mrow><mo>⊆</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi></mrow></math>,</p>
+<table id="S5.Ex109" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex109.m1" class="ltx_Math" alttext="\mathbb{P}\bigg{(}\bigcup_{i}A_{i}\bigg{)}=\sum_{i}\mathbb{P}(A_{i})" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo maxsize="210%" minsize="210%">(</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">⋃</mo><mi>i</mi></munder><msub><mi>A</mi><mi>i</mi></msub></mrow><mo maxsize="210%" minsize="210%">)</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>i</mi></munder><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>A</mi><mi>i</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</li>
+</ol>
+<p id="S5.SS1.p3.2" class="ltx_p">The triple <math id="S5.SS1.p3.2.m1" class="ltx_Math" alttext="(\Omega,\mathcal{F},\mathbb{P})" display="inline"><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo>,</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi><mo>,</mo><mi>ℙ</mi><mo stretchy="false">)</mo></mrow></math> is called a <span id="S5.SS1.p3.2.1" class="ltx_text ltx_font_bold">probability space</span>.<span id="footnote8" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">8</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">8</sup><span class="ltx_tag ltx_tag_note">8</span>
+Note that a probability space is simply a measure space in which the measure of the whole space equals 1.
+</span></span></span></p>
+</div>
+<div id="S5.SS1.p4" class="ltx_para ltx_noindent">
+<p id="S5.SS1.p4.4" class="ltx_p">If <math id="S5.SS1.p4.1.m1" class="ltx_Math" alttext="\mathbb{P}(A)=1" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math>, we say that <math id="S5.SS1.p4.2.m2" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> occurs <span id="S5.SS1.p4.4.1" class="ltx_text ltx_font_bold">almost surely</span> (often abbreviated a.s.).<span id="footnote9" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">9</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">9</sup><span class="ltx_tag ltx_tag_note">9</span>
+This is a probabilist’s version of the measure-theoretic term <span id="footnote9.1" class="ltx_text ltx_font_italic">almost everywhere</span>.
+</span></span></span>, and conversely <math id="S5.SS1.p4.3.m3" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> occurs <span id="S5.SS1.p4.4.2" class="ltx_text ltx_font_bold">almost never</span> if <math id="S5.SS1.p4.4.m4" class="ltx_Math" alttext="\mathbb{P}(A)=0" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math>.</p>
+</div>
+<div id="S5.SS1.p5" class="ltx_para">
+<p id="S5.SS1.p5.1" class="ltx_p">From these axioms, a number of useful rules can be derived.</p>
+</div>
+<div id="Thmproposition24" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition24.1.1.1" class="ltx_text ltx_font_bold">Proposition 24</span></span><span id="Thmproposition24.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition24.p1" class="ltx_para">
+<p id="Thmproposition24.p1.1" class="ltx_p"><span id="Thmproposition24.p1.1.1" class="ltx_text ltx_font_italic">Let <math id="Thmproposition24.p1.1.1.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> be an event. Then</span></p>
+<ol id="S5.I2" class="ltx_enumerate">
+<li id="S5.I2.i1" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S5.I2.i1.1.1.1" class="ltx_text">(i)</span></span> 
+<div id="S5.I2.i1.p1" class="ltx_para ltx_noindent">
+<p id="S5.I2.i1.p1.1" class="ltx_p"><math id="S5.I2.i1.p1.1.m1" class="ltx_Math" alttext="\mathbb{P}(A^{\text{c}})=1-\mathbb{P}(A)" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>A</mi><mtext>𝑐</mtext></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mn>1</mn><mo>-</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math><span id="S5.I2.i1.p1.1.1" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+<li id="S5.I2.i2" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S5.I2.i2.1.1.1" class="ltx_text">(ii)</span></span> 
+<div id="S5.I2.i2.p1" class="ltx_para ltx_noindent">
+<p id="S5.I2.i2.p1.3" class="ltx_p"><span id="S5.I2.i2.p1.3.1" class="ltx_text ltx_font_italic">If </span><math id="S5.I2.i2.p1.1.m1" class="ltx_Math" alttext="B" display="inline"><mi>B</mi></math><span id="S5.I2.i2.p1.3.2" class="ltx_text ltx_font_italic"> is an event and </span><math id="S5.I2.i2.p1.2.m2" class="ltx_Math" alttext="B\subseteq A" display="inline"><mrow><mi>B</mi><mo>⊆</mo><mi>A</mi></mrow></math><span id="S5.I2.i2.p1.3.3" class="ltx_text ltx_font_italic">, then </span><math id="S5.I2.i2.p1.3.m3" class="ltx_Math" alttext="\mathbb{P}(B)\leq\mathbb{P}(A)" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math><span id="S5.I2.i2.p1.3.4" class="ltx_text ltx_font_italic">.</span></p>
+</div>
+</li>
+<li id="S5.I2.i3" class="ltx_item" style="list-style-type:none;">
+<span class="ltx_tag ltx_tag_item"><span id="S5.I2.i3.1.1.1" class="ltx_text">(iii)</span></span> 
+<div id="S5.I2.i3.p1" class="ltx_para ltx_noindent">
+<p id="S5.I2.i3.p1.1" class="ltx_p"><math id="S5.I2.i3.p1.1.m1" class="ltx_Math" alttext="0=\mathbb{P}(\varnothing)\leq\mathbb{P}(A)\leq\mathbb{P}(\Omega)=1" display="inline"><mrow><mn>0</mn><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">∅</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≤</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math><span id="S5.I2.i3.p1.1.1" class="ltx_text ltx_font_italic"></span></p>
+</div>
+</li>
+</ol>
+</div>
+</div>
+<div id="S5.SS1.3" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S5.SS1.1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS1.1.p1.1" class="ltx_p">(i) Using the countable additivity of <math id="S5.SS1.1.p1.1.m1" class="ltx_Math" alttext="\mathbb{P}" display="inline"><mi>ℙ</mi></math>, we have</p>
+<table id="S5.Ex110" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex110.m1" class="ltx_Math" alttext="\mathbb{P}(A)+\mathbb{P}(A^{\text{c}})=\mathbb{P}(A\mathbin{\dot{\cup}}A^{%
+\text{c}})=\mathbb{P}(\Omega)=1" display="block"><mrow><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msup><mi>A</mi><mtext>c</mtext></msup><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><msup><mi>A</mi><mtext>c</mtext></msup></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<div id="S5.SS1.2.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS1.2.p2.2" class="ltx_p">To show (ii), suppose <math id="S5.SS1.2.p2.1.m1" class="ltx_Math" alttext="B\in\mathcal{F}" display="inline"><mrow><mi>B</mi><mo>∈</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi></mrow></math> and <math id="S5.SS1.2.p2.2.m2" class="ltx_Math" alttext="B\subseteq A" display="inline"><mrow><mi>B</mi><mo>⊆</mo><mi>A</mi></mrow></math>. Then</p>
+<table id="S5.Ex111" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex111.m1" class="ltx_Math" alttext="\mathbb{P}(A)=\mathbb{P}(B\mathbin{\dot{\cup}}(A\setminus B))=\mathbb{P}(B)+%
+\mathbb{P}(A\setminus B)\geq\mathbb{P}(B)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∖</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∖</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>≥</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.2.p2.3" class="ltx_p">as claimed.</p>
+</div>
+<div id="S5.SS1.3.p3" class="ltx_para">
+<p id="S5.SS1.3.p3.1" class="ltx_p">For (iii): the middle inequality follows from (ii) since <math id="S5.SS1.3.p3.1.m1" class="ltx_Math" alttext="\varnothing\subseteq A\subseteq\Omega" display="inline"><mrow><mi mathvariant="normal">∅</mi><mo>⊆</mo><mi>A</mi><mo>⊆</mo><mi mathvariant="normal">Ω</mi></mrow></math>.
+We also have</p>
+<table id="S5.Ex112" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex112.m1" class="ltx_Math" alttext="\mathbb{P}(\varnothing)=\mathbb{P}(\varnothing\mathbin{\dot{\cup}}\varnothing)%
+=\mathbb{P}(\varnothing)+\mathbb{P}(\varnothing)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">∅</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi mathvariant="normal">∅</mi><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><mi mathvariant="normal">∅</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">∅</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">∅</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.3.p3.2" class="ltx_p">by countable additivity, which shows <math id="S5.SS1.3.p3.2.m1" class="ltx_Math" alttext="\mathbb{P}(\varnothing)=0" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">∅</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math>.
+∎</p>
+</div>
+</div>
+<div id="Thmproposition25" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition25.1.1.1" class="ltx_text ltx_font_bold">Proposition 25</span></span><span id="Thmproposition25.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition25.p1" class="ltx_para">
+<p id="Thmproposition25.p1.3" class="ltx_p"><span id="Thmproposition25.p1.3.3" class="ltx_text ltx_font_italic">If <math id="Thmproposition25.p1.1.1.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> and <math id="Thmproposition25.p1.2.2.m2" class="ltx_Math" alttext="B" display="inline"><mi>B</mi></math> are events, then <math id="Thmproposition25.p1.3.3.m3" class="ltx_Math" alttext="\mathbb{P}(A\cup B)=\mathbb{P}(A)+\mathbb{P}(B)-\mathbb{P}(A\cap B)" display="inline"><mrow><mrow><mi>ℙ</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mrow><mi>A</mi><mo mathvariant="normal">∪</mo><mi>B</mi></mrow><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">=</mo><mrow><mrow><mrow><mi>ℙ</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>A</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow><mo mathvariant="normal">+</mo><mrow><mi>ℙ</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mi>B</mi><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></mrow><mo mathvariant="normal">-</mo><mrow><mi>ℙ</mi><mo mathvariant="italic">⁢</mo><mrow><mo mathvariant="normal" stretchy="false">(</mo><mrow><mi>A</mi><mo mathvariant="normal">∩</mo><mi>B</mi></mrow><mo mathvariant="normal" stretchy="false">)</mo></mrow></mrow></mrow></mrow></math>.</span></p>
+</div>
+</div>
+<div id="S5.SS1.4" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S5.SS1.4.p1" class="ltx_para">
+<p id="S5.SS1.4.p1.1" class="ltx_p">The key is to break the events up into their various overlapping and non-overlapping parts.</p>
+<table id="Sx1.EGx10" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S5.Ex113"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S5.Ex113.m1" class="ltx_Math" alttext="\displaystyle\mathbb{P}(A\cup B)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∪</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex113.m2" class="ltx_Math" alttext="\displaystyle=\mathbb{P}((A\cap B)\mathbin{\dot{\cup}}(A\setminus B)\mathbin{%
+\dot{\cup}}(B\setminus A))" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∖</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow><mover accent="true"><mo>∪</mo><mo>˙</mo></mover><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo>∖</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S5.Ex114"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex114.m1" class="ltx_Math" alttext="\displaystyle=\mathbb{P}(A\cap B)+\mathbb{P}(A\setminus B)+\mathbb{P}(B%
+\setminus A)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∖</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo>∖</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S5.Ex115"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex115.m1" class="ltx_Math" alttext="\displaystyle=\mathbb{P}(A\cap B)+\mathbb{P}(A)-\mathbb{P}(A\cap B)+\mathbb{P}%
+(B)-\mathbb{P}(A\cap B)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mrow><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>-</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>-</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S5.Ex116"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_eqn_cell"></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex116.m1" class="ltx_Math" alttext="\displaystyle=\mathbb{P}(A)+\mathbb{P}(B)-\mathbb{P}(A\cap B)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>-</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+<p id="S5.SS1.4.p1.2" class="ltx_p">∎</p>
+</div>
+</div>
+<div id="Thmproposition26" class="ltx_theorem ltx_theorem_proposition">
+<h6 class="ltx_title ltx_runin ltx_title_theorem">
+<span class="ltx_tag ltx_tag_theorem"><span id="Thmproposition26.1.1.1" class="ltx_text ltx_font_bold">Proposition 26</span></span><span id="Thmproposition26.2.2" class="ltx_text ltx_font_bold">.</span>
+</h6>
+<div id="Thmproposition26.p1" class="ltx_para">
+<p id="Thmproposition26.p1.1" class="ltx_p"><span id="Thmproposition26.p1.1.1" class="ltx_text ltx_font_italic">If <math id="Thmproposition26.p1.1.1.m1" class="ltx_Math" alttext="\{A_{i}\}\subseteq\mathcal{F}" display="inline"><mrow><mrow><mo mathvariant="normal" stretchy="false">{</mo><msub><mi>A</mi><mi>i</mi></msub><mo mathvariant="normal" stretchy="false">}</mo></mrow><mo mathvariant="normal">⊆</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi></mrow></math> is a countable set of events, disjoint or not, then</span></p>
+<table id="S5.Ex117" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex117.m1" class="ltx_Math" alttext="\mathbb{P}\bigg{(}\bigcup_{i}A_{i}\bigg{)}\leq\sum_{i}\mathbb{P}(A_{i})" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo maxsize="210%" minsize="210%">(</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">⋃</mo><mi>i</mi></munder><msub><mi>A</mi><mi>i</mi></msub></mrow><mo maxsize="210%" minsize="210%">)</mo></mrow></mrow><mo>≤</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>i</mi></munder><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>A</mi><mi>i</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</div>
+<div id="S5.SS1.p6" class="ltx_para">
+<p id="S5.SS1.p6.1" class="ltx_p">This inequality is sometimes referred to as <span id="S5.SS1.p6.1.1" class="ltx_text ltx_font_bold">Boole’s inequality</span> or the <span id="S5.SS1.p6.1.2" class="ltx_text ltx_font_bold">union bound</span>.</p>
+</div>
+<div id="S5.SS1.5" class="ltx_proof">
+<h6 class="ltx_title ltx_runin ltx_font_italic ltx_title_proof">Proof.</h6>
+<div id="S5.SS1.5.p1" class="ltx_para">
+<p id="S5.SS1.5.p1.6" class="ltx_p">Define <math id="S5.SS1.5.p1.1.m1" class="ltx_Math" alttext="B_{1}=A_{1}" display="inline"><mrow><msub><mi>B</mi><mn>1</mn></msub><mo>=</mo><msub><mi>A</mi><mn>1</mn></msub></mrow></math> and <math id="S5.SS1.5.p1.2.m2" class="ltx_Math" alttext="B_{i}=A_{i}\setminus(\bigcup_{j&lt;i}A_{j})" display="inline"><mrow><msub><mi>B</mi><mi>i</mi></msub><mo>=</mo><mrow><msub><mi>A</mi><mi>i</mi></msub><mo>∖</mo><mrow><mo stretchy="false">(</mo><mrow><msub><mo largeop="true" symmetric="true">⋃</mo><mrow><mi>j</mi><mo>&lt;</mo><mi>i</mi></mrow></msub><msub><mi>A</mi><mi>j</mi></msub></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math> for <math id="S5.SS1.5.p1.3.m3" class="ltx_Math" alttext="i&gt;1" display="inline"><mrow><mi>i</mi><mo>&gt;</mo><mn>1</mn></mrow></math>, noting that <math id="S5.SS1.5.p1.4.m4" class="ltx_Math" alttext="\bigcup_{j\leq i}B_{j}=\bigcup_{j\leq i}A_{j}" display="inline"><mrow><mrow><msub><mo largeop="true" symmetric="true">⋃</mo><mrow><mi>j</mi><mo>≤</mo><mi>i</mi></mrow></msub><msub><mi>B</mi><mi>j</mi></msub></mrow><mo>=</mo><mrow><msub><mo largeop="true" symmetric="true">⋃</mo><mrow><mi>j</mi><mo>≤</mo><mi>i</mi></mrow></msub><msub><mi>A</mi><mi>j</mi></msub></mrow></mrow></math> for all <math id="S5.SS1.5.p1.5.m5" class="ltx_Math" alttext="i" display="inline"><mi>i</mi></math> and the <math id="S5.SS1.5.p1.6.m6" class="ltx_Math" alttext="B_{i}" display="inline"><msub><mi>B</mi><mi>i</mi></msub></math> are disjoint.
+Then</p>
+<table id="S5.Ex118" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex118.m1" class="ltx_Math" alttext="\mathbb{P}\bigg{(}\bigcup_{i}A_{i}\bigg{)}=\mathbb{P}\bigg{(}\bigcup_{i}B_{i}%
+\bigg{)}=\sum_{i}\mathbb{P}(B_{i})\leq\sum_{i}\mathbb{P}(A_{i})" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo maxsize="210%" minsize="210%">(</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">⋃</mo><mi>i</mi></munder><msub><mi>A</mi><mi>i</mi></msub></mrow><mo maxsize="210%" minsize="210%">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo maxsize="210%" minsize="210%">(</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">⋃</mo><mi>i</mi></munder><msub><mi>B</mi><mi>i</mi></msub></mrow><mo maxsize="210%" minsize="210%">)</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>i</mi></munder><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>B</mi><mi>i</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>≤</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>i</mi></munder><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>A</mi><mi>i</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.5.p1.8" class="ltx_p">where the last inequality follows by monotonicity since <math id="S5.SS1.5.p1.7.m1" class="ltx_Math" alttext="B_{i}\subseteq A_{i}" display="inline"><mrow><msub><mi>B</mi><mi>i</mi></msub><mo>⊆</mo><msub><mi>A</mi><mi>i</mi></msub></mrow></math> for all <math id="S5.SS1.5.p1.8.m2" class="ltx_Math" alttext="i" display="inline"><mi>i</mi></math>.
+∎</p>
+</div>
+</div>
+<section id="S5.SS1.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.1.1 </span>Conditional probability</h4>
+
+<div id="S5.SS1.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS1.SSS1.p1.3" class="ltx_p">The <span id="S5.SS1.SSS1.p1.3.1" class="ltx_text ltx_font_bold">conditional probability</span> of event <math id="S5.SS1.SSS1.p1.1.m1" class="ltx_Math" alttext="A" display="inline"><mi>A</mi></math> given that event <math id="S5.SS1.SSS1.p1.2.m2" class="ltx_Math" alttext="B" display="inline"><mi>B</mi></math> has occurred is written <math id="S5.SS1.SSS1.p1.3.m3" class="ltx_Math" alttext="\mathbb{P}(A|B)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></math> and defined as</p>
+<table id="S5.Ex119" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex119.m1" class="ltx_Math" alttext="\mathbb{P}(A|B)=\frac{\mathbb{P}(A\cap B)}{\mathbb{P}(B)}" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mfrac><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow></mfrac></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.SSS1.p1.4" class="ltx_p">assuming <math id="S5.SS1.SSS1.p1.4.m1" class="ltx_Math" alttext="\mathbb{P}(B)&gt;0" display="inline"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow><mo>&gt;</mo><mn>0</mn></mrow></math>.<span id="footnote10" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">10</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">10</sup><span class="ltx_tag ltx_tag_note">10</span>
+In some cases it is possible to define conditional probability on events of probability zero, but this is significantly more technical so we omit it.
+</span></span></span></p>
+</div>
+</section>
+<section id="S5.SS1.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.1.2 </span>Chain rule</h4>
+
+<div id="S5.SS1.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS1.SSS2.p1.1" class="ltx_p">Another very useful tool, the <span id="S5.SS1.SSS2.p1.1.1" class="ltx_text ltx_font_bold">chain rule</span>, follows immediately from this definition:</p>
+<table id="S5.Ex120" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex120.m1" class="ltx_Math" alttext="\mathbb{P}(A\cap B)=\mathbb{P}(A|B)\mathbb{P}(B)=\mathbb{P}(B|A)\mathbb{P}(A)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo>∩</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S5.SS1.SSS3" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.1.3 </span>Bayes’ rule</h4>
+
+<div id="S5.SS1.SSS3.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS1.SSS3.p1.4" class="ltx_p">Taking the equality from above one step further, we arrive at the simple but crucial <span id="S5.SS1.SSS3.p1.4.1" class="ltx_text ltx_font_bold">Bayes’ rule</span>:</p>
+<table id="S5.Ex121" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex121.m1" class="ltx_Math" alttext="\mathbb{P}(A|B)=\frac{\mathbb{P}(B|A)\mathbb{P}(A)}{\mathbb{P}(B)}" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mfrac><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>B</mi><mo stretchy="false">)</mo></mrow></mrow></mfrac></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.SSS3.p1.5" class="ltx_p">It is sometimes beneficial to omit the normalizing constant and write</p>
+<table id="S5.Ex122" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex122.m1" class="ltx_Math" alttext="\mathbb{P}(A|B)\propto\mathbb{P}(A)\mathbb{P}(B|A)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>∝</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS1.SSS3.p1.3" class="ltx_p">Under this formulation, <math id="S5.SS1.SSS3.p1.1.m1" class="ltx_Math" alttext="\mathbb{P}(A)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow></mrow></math> is often referred to as the <span id="S5.SS1.SSS3.p1.3.1" class="ltx_text ltx_font_bold">prior</span>, <math id="S5.SS1.SSS3.p1.2.m2" class="ltx_Math" alttext="\mathbb{P}(A|B)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>A</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>B</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></math> as the <span id="S5.SS1.SSS3.p1.3.2" class="ltx_text ltx_font_bold">posterior</span>, and <math id="S5.SS1.SSS3.p1.3.m3" class="ltx_Math" alttext="\mathbb{P}(B|A)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>B</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>A</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></math> as the <span id="S5.SS1.SSS3.p1.3.3" class="ltx_text ltx_font_bold">likelihood</span>.</p>
+</div>
+<div id="S5.SS1.SSS3.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS1.SSS3.p2.1" class="ltx_p">In the context of machine learning, we can use Bayes’ rule to update our “beliefs” (e.g. values of our model parameters) given some data that we’ve observed.</p>
+</div>
+</section>
+</section>
+<section id="S5.SS2" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.2 </span>Random variables</h3>
+
+<div id="S5.SS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS2.p1.1" class="ltx_p">A <span id="S5.SS2.p1.1.1" class="ltx_text ltx_font_bold">random variable</span> is some uncertain quantity with an associated probability distribution over the values it can assume.</p>
+</div>
+<div id="S5.SS2.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS2.p2.2" class="ltx_p">Formally, a random variable on a probability space <math id="S5.SS2.p2.1.m1" class="ltx_Math" alttext="(\Omega,\mathcal{F},\mathbb{P})" display="inline"><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo>,</mo><mi class="ltx_font_mathcaligraphic">ℱ</mi><mo>,</mo><mi>ℙ</mi><mo stretchy="false">)</mo></mrow></math> is a function<span id="footnote11" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">11</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">11</sup><span class="ltx_tag ltx_tag_note">11</span>
+The function must be measurable.
+</span></span></span> <math id="S5.SS2.p2.2.m2" class="ltx_Math" alttext="X\mathrel{\mathop{:}}\Omega\to\mathbb{R}" display="inline"><mrow><mi>X</mi><mo>:</mo><mi mathvariant="normal">Ω</mi><mo>→</mo><mi>ℝ</mi></mrow></math>.<span id="footnote12" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">12</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">12</sup><span class="ltx_tag ltx_tag_note">12</span>
+More generally, the codomain can be any measurable space, but <math id="footnote12.m1" class="ltx_Math" alttext="\mathbb{R}" display="inline"><mi>ℝ</mi></math> is the most common case by far and sufficient for our purposes.
+</span></span></span></p>
+</div>
+<div id="S5.SS2.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS2.p3.3" class="ltx_p">We denote the range of <math id="S5.SS2.p3.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> by <math id="S5.SS2.p3.2.m2" class="ltx_Math" alttext="X(\Omega)=\{X(\omega)\mathrel{\mathop{:}}\omega\in\Omega\}" display="inline"><mrow><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>:</mo><mi>ω</mi><mo>∈</mo><mi mathvariant="normal">Ω</mi></mrow><mo stretchy="false">}</mo></mrow></mrow></math>.
+To give a concrete example (taken from <cite class="ltx_cite ltx_citemacro_cite">[<a href="#bib.bib4" title="Probability" class="ltx_ref">2</a>]</cite>), suppose <math id="S5.SS2.p3.3.m3" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> is the number of heads in two tosses of a fair coin.
+The sample space is</p>
+<table id="S5.Ex123" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex123.m1" class="ltx_Math" alttext="\Omega=\{hh,tt,ht,th\}" display="block"><mrow><mi mathvariant="normal">Ω</mi><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>h</mi><mo>⁢</mo><mi>h</mi></mrow><mo>,</mo><mrow><mi>t</mi><mo>⁢</mo><mi>t</mi></mrow><mo>,</mo><mrow><mi>h</mi><mo>⁢</mo><mi>t</mi></mrow><mo>,</mo><mrow><mi>t</mi><mo>⁢</mo><mi>h</mi></mrow><mo stretchy="false">}</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.p3.8" class="ltx_p">and <math id="S5.SS2.p3.4.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> is determined completely by the outcome <math id="S5.SS2.p3.5.m2" class="ltx_Math" alttext="\omega" display="inline"><mi>ω</mi></math>, i.e. <math id="S5.SS2.p3.6.m3" class="ltx_Math" alttext="X=X(\omega)" display="inline"><mrow><mi>X</mi><mo>=</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>ω</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+For example, the event <math id="S5.SS2.p3.7.m4" class="ltx_Math" alttext="X=1" display="inline"><mrow><mi>X</mi><mo>=</mo><mn>1</mn></mrow></math> is the set of outcomes <math id="S5.SS2.p3.8.m5" class="ltx_Math" alttext="\{ht,th\}" display="inline"><mrow><mo stretchy="false">{</mo><mrow><mi>h</mi><mo>⁢</mo><mi>t</mi></mrow><mo>,</mo><mrow><mi>t</mi><mo>⁢</mo><mi>h</mi></mrow><mo stretchy="false">}</mo></mrow></math>.</p>
+</div>
+<div id="S5.SS2.p4" class="ltx_para ltx_noindent">
+<p id="S5.SS2.p4.2" class="ltx_p">It is common to talk about the values of a random variable without directly referencing its sample space.
+The two are related by the following definition: the event that the value of <math id="S5.SS2.p4.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> lies in some set <math id="S5.SS2.p4.2.m2" class="ltx_Math" alttext="S\subseteq\mathbb{R}" display="inline"><mrow><mi>S</mi><mo>⊆</mo><mi>ℝ</mi></mrow></math> is</p>
+<table id="S5.Ex124" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex124.m1" class="ltx_Math" alttext="X\in S=\{\omega\in\Omega\mathrel{\mathop{:}}X(\omega)\in S\}" display="block"><mrow><mi>X</mi><mo>∈</mo><mi>S</mi><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>ω</mi><mo>∈</mo><mi mathvariant="normal">Ω</mi><mo movablelimits="false">:</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>∈</mo><mi>S</mi></mrow><mo stretchy="false">}</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.p4.3" class="ltx_p">Note that special cases of this definition include <math id="S5.SS2.p4.3.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> being equal to, less than, or greater than some specified value.
+For example</p>
+<table id="S5.Ex125" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex125.m1" class="ltx_Math" alttext="\mathbb{P}(X=x)=\mathbb{P}(\{\omega\in\Omega\mathrel{\mathop{:}}X(\omega)=x\})" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>X</mi><mo>=</mo><mi>x</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mo stretchy="false">{</mo><mrow><mi>ω</mi><mo>∈</mo><mi mathvariant="normal">Ω</mi><mo movablelimits="false">:</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mi>x</mi></mrow><mo stretchy="false">}</mo></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<div id="S5.SS2.p5" class="ltx_para ltx_noindent">
+<p id="S5.SS2.p5.9" class="ltx_p">A word on notation: we write <math id="S5.SS2.p5.1.m1" class="ltx_Math" alttext="p(X)" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></math> to denote the entire probability distribution of <math id="S5.SS2.p5.2.m2" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and <math id="S5.SS2.p5.3.m3" class="ltx_Math" alttext="p(x)" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></math> for the evaluation of the function <math id="S5.SS2.p5.4.m4" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math> at a particular value <math id="S5.SS2.p5.5.m5" class="ltx_Math" alttext="x\in X(\Omega)" display="inline"><mrow><mi>x</mi><mo>∈</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+Hopefully this (reasonably standard) abuse of notation is not too distracting.
+If <math id="S5.SS2.p5.6.m6" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math> is parameterized by some parameters <math id="S5.SS2.p5.7.m7" class="ltx_Math" alttext="\theta" display="inline"><mi>θ</mi></math>, we write <math id="S5.SS2.p5.8.m8" class="ltx_Math" alttext="p(X;\mathbf{\theta})" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></math> or <math id="S5.SS2.p5.9.m9" class="ltx_Math" alttext="p(x;\mathbf{\theta})" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></math>, unless we are in a Bayesian setting where the parameters are considered a random variable, in which case we condition on the parameters.</p>
+</div>
+<section id="S5.SS2.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.2.1 </span>The cumulative distribution function</h4>
+
+<div id="S5.SS2.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS1.p1.1" class="ltx_p">The <span id="S5.SS2.SSS1.p1.1.1" class="ltx_text ltx_font_bold">cumulative distribution function</span> (c.d.f.) gives the probability that a random variable is at most a certain value:</p>
+<table id="S5.Ex126" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex126.m1" class="ltx_Math" alttext="F(x)=\mathbb{P}(X\leq x)" display="block"><mrow><mrow><mi>F</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>X</mi><mo>≤</mo><mi>x</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.SSS1.p1.2" class="ltx_p">The c.d.f. can be used to give the probability that a variable lies within a certain range:</p>
+<table id="S5.Ex127" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex127.m1" class="ltx_Math" alttext="\mathbb{P}(a&lt;X\leq b)=F(b)-F(a)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>a</mi><mo>&lt;</mo><mi>X</mi><mo>≤</mo><mi>b</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>F</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>b</mi><mo stretchy="false">)</mo></mrow></mrow><mo>-</mo><mrow><mi>F</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>a</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S5.SS2.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.2.2 </span>Discrete random variables</h4>
+
+<div id="S5.SS2.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS2.p1.1" class="ltx_p">A <span id="S5.SS2.SSS2.p1.1.1" class="ltx_text ltx_font_bold">discrete random variable</span> is a random variable that has a countable range and assumes each value in this range with positive probability.
+Discrete random variables are completely specified by their <span id="S5.SS2.SSS2.p1.1.2" class="ltx_text ltx_font_bold">probability mass function</span> (p.m.f.) <math id="S5.SS2.SSS2.p1.1.m1" class="ltx_Math" alttext="p\mathrel{\mathop{:}}X(\Omega)\to[0,1]" display="inline"><mrow><mi>p</mi><mo>:</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow><mo>→</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo stretchy="false">]</mo></mrow></mrow></math> which satisfies</p>
+<table id="S5.Ex128" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex128.m1" class="ltx_Math" alttext="\sum_{x\in X(\Omega)}p(x)=1" display="block"><mrow><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>x</mi><mo>∈</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></munder><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.SSS2.p1.2" class="ltx_p">For a discrete <math id="S5.SS2.SSS2.p1.2.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>, the probability of a particular value is given exactly by its p.m.f.:</p>
+<table id="S5.Ex129" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex129.m1" class="ltx_Math" alttext="\mathbb{P}(X=x)=p(x)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>X</mi><mo>=</mo><mi>x</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S5.SS2.SSS3" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.2.3 </span>Continuous random variables</h4>
+
+<div id="S5.SS2.SSS3.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS3.p1.1" class="ltx_p">A <span id="S5.SS2.SSS3.p1.1.1" class="ltx_text ltx_font_bold">continuous random variable</span> is a random variable that has an uncountable range and assumes each value in this range with probability zero.
+Most of the continuous random variables that one would encounter in practice are <span id="S5.SS2.SSS3.p1.1.2" class="ltx_text ltx_font_bold">absolutely continuous random variables<span id="footnote13" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">13</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">13</sup><span class="ltx_tag ltx_tag_note"><span id="footnote13.1.1.1" class="ltx_text ltx_font_medium">13</span></span><span id="footnote13.5" class="ltx_text ltx_font_medium">
+Random variables that are continuous but not absolutely continuous are called </span><span id="footnote13.6" class="ltx_text">singular random variables</span><span id="footnote13.7" class="ltx_text ltx_font_medium">.
+We will not discuss them, assuming rather that all continuous random variables admit a density function.
+</span></span></span></span></span>, which means that there exists a function <math id="S5.SS2.SSS3.p1.1.m1" class="ltx_Math" alttext="p\mathrel{\mathop{:}}\mathbb{R}\to[0,\infty)" display="inline"><mrow><mi>p</mi><mo>:</mo><mi>ℝ</mi><mo>→</mo><mrow><mo stretchy="false">[</mo><mn>0</mn><mo>,</mo><mi mathvariant="normal">∞</mi><mo stretchy="false">)</mo></mrow></mrow></math> that satisfies</p>
+<table id="S5.Ex130" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex130.m1" class="ltx_Math" alttext="F(x)\equiv\int_{-\infty}^{x}p(z)\differential{z}" display="block"><mrow><mrow><mi>F</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow><mo>≡</mo><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mrow><mo>-</mo><mi mathvariant="normal">∞</mi></mrow><mi>x</mi></msubsup><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>z</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>z</mi></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.SSS3.p1.2" class="ltx_p">The function <math id="S5.SS2.SSS3.p1.2.m1" class="ltx_Math" alttext="p" display="inline"><mi>p</mi></math> is called a <span id="S5.SS2.SSS3.p1.2.1" class="ltx_text ltx_font_bold">probability density function</span> (abbreviated p.d.f.) and must satisfy</p>
+<table id="S5.Ex131" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex131.m1" class="ltx_Math" alttext="\int_{-\infty}^{\infty}p(x)\differential{x}=1" display="block"><mrow><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mrow><mo>-</mo><mi mathvariant="normal">∞</mi></mrow><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>x</mi></mrow></mrow></mrow><mo>=</mo><mn>1</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.SSS3.p1.3" class="ltx_p">The values of this function are not themselves probabilities, since they could exceed 1.
+However, they do have a couple of reasonable interpretations.
+One is as relative probabilities; even though the probability of each particular value being picked is technically zero, some points are still in a sense more likely than others.</p>
+</div>
+<div id="S5.SS2.SSS3.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS3.p2.1" class="ltx_p">One can also think of the density as determining the probability that the variable will lie in a small range about a given value.
+This is because, for small <math id="S5.SS2.SSS3.p2.1.m1" class="ltx_Math" alttext="\epsilon&gt;0" display="inline"><mrow><mi>ϵ</mi><mo>&gt;</mo><mn>0</mn></mrow></math>,
+</p>
+<table id="S5.Ex132" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex132.m1" class="ltx_Math" alttext="\mathbb{P}(x-\epsilon\leq X\leq x+\epsilon)=\int_{x-\epsilon}^{x+\epsilon}p(z)%
+\differential{z}\approx 2\epsilon p(x)" display="block"><mrow><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>x</mi><mo>-</mo><mi>ϵ</mi></mrow><mo>≤</mo><mi>X</mi><mo>≤</mo><mrow><mi>x</mi><mo>+</mo><mi>ϵ</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mrow><mi>x</mi><mo>-</mo><mi>ϵ</mi></mrow><mrow><mi>x</mi><mo>+</mo><mi>ϵ</mi></mrow></msubsup><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>z</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>z</mi></mrow></mrow></mrow><mo>≈</mo><mrow><mn>2</mn><mo>⁢</mo><mi>ϵ</mi><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS2.SSS3.p2.2" class="ltx_p">using a midpoint approximation to the integral.</p>
+</div>
+<div id="S5.SS2.SSS3.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS3.p3.1" class="ltx_p">Here are some useful identities that follow from the definitions above:</p>
+<table id="Sx1.EGx11" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S5.Ex133"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S5.Ex133.m1" class="ltx_Math" alttext="\displaystyle\mathbb{P}(a\leq X\leq b)" display="inline"><mrow><mi>ℙ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>a</mi><mo>≤</mo><mi>X</mi><mo>≤</mo><mi>b</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex133.m2" class="ltx_Math" alttext="\displaystyle=\int_{a}^{b}p(x)\differential{x}" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mstyle displaystyle="true"><msubsup><mo largeop="true" symmetric="true">∫</mo><mi>a</mi><mi>b</mi></msubsup></mstyle><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>x</mi></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S5.Ex134"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S5.Ex134.m1" class="ltx_Math" alttext="\displaystyle p(x)" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex134.m2" class="ltx_Math" alttext="\displaystyle=F^{\prime}(x)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><msup><mi>F</mi><mo>′</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+</div>
+</section>
+<section id="S5.SS2.SSS4" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.2.4 </span>Other kinds of random variables</h4>
+
+<div id="S5.SS2.SSS4.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS2.SSS4.p1.1" class="ltx_p">There are random variables that are neither discrete nor continuous.
+For example, consider a random variable determined as follows:
+flip a fair coin, then the value is zero if it comes up heads, otherwise draw a number uniformly at random from <math id="S5.SS2.SSS4.p1.1.m1" class="ltx_Math" alttext="[1,2]" display="inline"><mrow><mo stretchy="false">[</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo stretchy="false">]</mo></mrow></math>.
+Such a random variable can take on uncountably many values, but only finitely many of these with positive probability.
+We will not discuss such random variables because they are rather pathological and require measure theory to analyze.</p>
+</div>
+</section>
+</section>
+<section id="S5.SS3" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.3 </span>Joint distributions</h3>
+
+<div id="S5.SS3.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS3.p1.3" class="ltx_p">Often we have several random variables and we would like to get a distribution over some combination of them.
+A <span id="S5.SS3.p1.3.1" class="ltx_text ltx_font_bold">joint distribution</span> is exactly this.
+For some random variables <math id="S5.SS3.p1.1.m1" class="ltx_Math" alttext="X_{1},\dots,X_{n}" display="inline"><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub></mrow></math>, the joint distribution is written <math id="S5.SS3.p1.2.m2" class="ltx_Math" alttext="p(X_{1},\dots,X_{n})" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></math> and gives probabilities over entire assignments to all the <math id="S5.SS3.p1.3.m3" class="ltx_Math" alttext="X_{i}" display="inline"><msub><mi>X</mi><mi>i</mi></msub></math> simultaneously.</p>
+</div>
+<section id="S5.SS3.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.3.1 </span>Independence of random variables</h4>
+
+<div id="S5.SS3.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS3.SSS1.p1.2" class="ltx_p">We say that two variables <math id="S5.SS3.SSS1.p1.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and <math id="S5.SS3.SSS1.p1.2.m2" class="ltx_Math" alttext="Y" display="inline"><mi>Y</mi></math> are <span id="S5.SS3.SSS1.p1.2.1" class="ltx_text ltx_font_bold">independent</span> if their joint distribution factors into their respective distributions, i.e.</p>
+<table id="S5.Ex135" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex135.m1" class="ltx_Math" alttext="p(X,Y)=p(X)p(Y)" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS3.SSS1.p1.6" class="ltx_p">We can also define independence for more than two random variables, although it is more complicated.
+Let <math id="S5.SS3.SSS1.p1.3.m1" class="ltx_Math" alttext="\{X_{i}\}_{i\in I}" display="inline"><msub><mrow><mo stretchy="false">{</mo><msub><mi>X</mi><mi>i</mi></msub><mo stretchy="false">}</mo></mrow><mrow><mi>i</mi><mo>∈</mo><mi>I</mi></mrow></msub></math> be a collection of random variables indexed by <math id="S5.SS3.SSS1.p1.4.m2" class="ltx_Math" alttext="I" display="inline"><mi>I</mi></math>, which may be infinite.
+Then <math id="S5.SS3.SSS1.p1.5.m3" class="ltx_Math" alttext="\{X_{i}\}" display="inline"><mrow><mo stretchy="false">{</mo><msub><mi>X</mi><mi>i</mi></msub><mo stretchy="false">}</mo></mrow></math> are independent if for every finite subset of indices <math id="S5.SS3.SSS1.p1.6.m4" class="ltx_Math" alttext="i_{1},\dots,i_{k}\in I" display="inline"><mrow><mrow><msub><mi>i</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>i</mi><mi>k</mi></msub></mrow><mo>∈</mo><mi>I</mi></mrow></math> we have</p>
+<table id="S5.Ex136" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex136.m1" class="ltx_Math" alttext="p(X_{i_{1}},\dots,X_{i_{k}})=\prod_{j=1}^{k}p(X_{i_{j}})" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><msub><mi>i</mi><mn>1</mn></msub></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><msub><mi>i</mi><mi>k</mi></msub></msub><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mrow><mi>j</mi><mo>=</mo><mn>1</mn></mrow><mi>k</mi></munderover><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><msub><mi>i</mi><mi>j</mi></msub></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS3.SSS1.p1.11" class="ltx_p">For example, in the case of three random variables, <math id="S5.SS3.SSS1.p1.7.m1" class="ltx_Math" alttext="X,Y,Z" display="inline"><mrow><mi>X</mi><mo>,</mo><mi>Y</mi><mo>,</mo><mi>Z</mi></mrow></math>, we require that <math id="S5.SS3.SSS1.p1.8.m2" class="ltx_Math" alttext="p(X,Y,Z)=p(X)p(Y)p(Z)" display="inline"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> as well as <math id="S5.SS3.SSS1.p1.9.m3" class="ltx_Math" alttext="p(X,Y)=p(X)p(Y)" display="inline"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>, <math id="S5.SS3.SSS1.p1.10.m4" class="ltx_Math" alttext="p(X,Z)=p(X)p(Z)" display="inline"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>, and <math id="S5.SS3.SSS1.p1.11.m5" class="ltx_Math" alttext="p(Y,Z)=p(Y)p(Z)" display="inline"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.</p>
+</div>
+<div id="S5.SS3.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS3.SSS1.p2.2" class="ltx_p">It is often convenient (though perhaps questionable) to assume that a bunch of random variables are <span id="S5.SS3.SSS1.p2.2.1" class="ltx_text ltx_font_bold">independent and identically distributed</span> (i.i.d.) so that their joint distribution can be factored entirely:</p>
+<table id="S5.Ex137" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex137.m1" class="ltx_Math" alttext="p(X_{1},\dots,X_{n})=\prod_{i=1}^{n}p(X_{i})" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>i</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS3.SSS1.p2.1" class="ltx_p">where <math id="S5.SS3.SSS1.p2.1.m1" class="ltx_Math" alttext="X_{1},\dots,X_{n}" display="inline"><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub></mrow></math> all share the same p.m.f./p.d.f.</p>
+</div>
+</section>
+<section id="S5.SS3.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.3.2 </span>Marginal distributions</h4>
+
+<div id="S5.SS3.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS3.SSS2.p1.1" class="ltx_p">If we have a joint distribution over some set of random variables, it is possible to obtain a distribution for a subset of them by “summing out” (or “integrating out” in the continuous case) the variables we don’t care about:</p>
+<table id="S5.Ex138" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex138.m1" class="ltx_Math" alttext="p(X)=\sum_{y}p(X,y)" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mi>y</mi></munder><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>y</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+</section>
+<section id="S5.SS4" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.4 </span>Great Expectations</h3>
+
+<div id="S5.SS4.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS4.p1.3" class="ltx_p">If we have some random variable <math id="S5.SS4.p1.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>, we might be interested in knowing what is the “average” value of <math id="S5.SS4.p1.2.m2" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>.
+This concept is captured by the <span id="S5.SS4.p1.3.1" class="ltx_text ltx_font_bold">expected value</span> (or <span id="S5.SS4.p1.3.2" class="ltx_text ltx_font_bold">mean</span>) <math id="S5.SS4.p1.3.m3" class="ltx_Math" alttext="\mathbb{E}[X]" display="inline"><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow></math>, which is defined as</p>
+<table id="S5.Ex139" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex139.m1" class="ltx_Math" alttext="\mathbb{E}[X]=\sum_{x\in X(\Omega)}xp(x)" display="block"><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow><mo>=</mo><mrow><munder><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>x</mi><mo>∈</mo><mrow><mi>X</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">Ω</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></munder><mrow><mi>x</mi><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS4.p1.4" class="ltx_p">for discrete <math id="S5.SS4.p1.4.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and as</p>
+<table id="S5.Ex140" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex140.m1" class="ltx_Math" alttext="\mathbb{E}[X]=\int_{-\infty}^{\infty}xp(x)\differential{x}" display="block"><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow><mo>=</mo><mrow><msubsup><mo largeop="true" symmetric="true">∫</mo><mrow><mo>-</mo><mi mathvariant="normal">∞</mi></mrow><mi mathvariant="normal">∞</mi></msubsup><mrow><mi>x</mi><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo rspace="0pt">d</mo><mi>x</mi></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS4.p1.5" class="ltx_p">for continuous <math id="S5.SS4.p1.5.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>.</p>
+</div>
+<div id="S5.SS4.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS4.p2.1" class="ltx_p">In words, we are taking a weighted sum of the values that <math id="S5.SS4.p2.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> can take on, where the weights are the probabilities of those respective values.
+The expected value has a physical interpretation as the “center of mass” of the distribution.</p>
+</div>
+<section id="S5.SS4.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.4.1 </span>Properties of expected value</h4>
+
+<div id="S5.SS4.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS4.SSS1.p1.2" class="ltx_p">A very useful property of expectation is that of linearity:</p>
+<table id="S5.Ex141" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex141.m1" class="ltx_Math" alttext="\mathbb{E}\left[\sum_{i=1}^{n}\alpha_{i}X_{i}+\beta\right]=\sum_{i=1}^{n}%
+\alpha_{i}\mathbb{E}[X_{i}]+\beta" display="block"><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo>[</mo><mrow><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>α</mi><mi>i</mi></msub><mo>⁢</mo><msub><mi>X</mi><mi>i</mi></msub></mrow></mrow><mo>+</mo><mi>β</mi></mrow><mo>]</mo></mrow></mrow><mo>=</mo><mrow><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><msub><mi>α</mi><mi>i</mi></msub><mo>⁢</mo><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msub><mi>X</mi><mi>i</mi></msub><mo stretchy="false">]</mo></mrow></mrow></mrow><mo>+</mo><mi>β</mi></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS4.SSS1.p1.1" class="ltx_p">Note that this holds even if the <math id="S5.SS4.SSS1.p1.1.m1" class="ltx_Math" alttext="X_{i}" display="inline"><msub><mi>X</mi><mi>i</mi></msub></math> are not independent!</p>
+</div>
+<div id="S5.SS4.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS4.SSS1.p2.1" class="ltx_p">But if they are independent, the product rule also holds:</p>
+<table id="S5.Ex142" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex142.m1" class="ltx_Math" alttext="\mathbb{E}\left[\prod_{i=1}^{n}X_{i}\right]=\prod_{i=1}^{n}\mathbb{E}[X_{i}]" display="block"><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo>[</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><msub><mi>X</mi><mi>i</mi></msub></mrow><mo>]</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msub><mi>X</mi><mi>i</mi></msub><mo stretchy="false">]</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+</section>
+<section id="S5.SS5" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.5 </span>Variance</h3>
+
+<div id="S5.SS5.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS5.p1.2" class="ltx_p">Expectation provides a measure of the “center” of a distribution, but frequently we are also interested in what the “spread” is about that center.
+We define the variance <math id="S5.SS5.p1.1.m1" class="ltx_Math" alttext="\operatorname{Var}(X)" display="inline"><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></math> of a random variable <math id="S5.SS5.p1.2.m2" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> by</p>
+<table id="S5.Ex143" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex143.m1" class="ltx_Math" alttext="\operatorname{Var}(X)=\mathbb{E}\left[\left(X-\mathbb{E}[X]\right)^{2}\right]" display="block"><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo>[</mo><msup><mrow><mo>(</mo><mrow><mi>X</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo>)</mo></mrow><mn>2</mn></msup><mo>]</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS5.p1.4" class="ltx_p">In words, this is the average squared deviation of the values of <math id="S5.SS5.p1.3.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> from the mean of <math id="S5.SS5.p1.4.m2" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>.
+Using a little algebra and the linearity of expectation, it is straightforward to show that</p>
+<table id="S5.Ex144" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex144.m1" class="ltx_Math" alttext="\operatorname{Var}(X)=\mathbb{E}[X^{2}]-\mathbb{E}[X]^{2}" display="block"><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msup><mi>X</mi><mn>2</mn></msup><mo stretchy="false">]</mo></mrow></mrow><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><msup><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow><mn>2</mn></msup></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<section id="S5.SS5.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.5.1 </span>Properties of variance</h4>
+
+<div id="S5.SS5.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS5.SSS1.p1.1" class="ltx_p">Variance is not linear (because of the squaring in the definition), but one can show the following:</p>
+<table id="S5.Ex145" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex145.m1" class="ltx_Math" alttext="\operatorname{Var}(\alpha X+\beta)=\alpha^{2}\operatorname{Var}(X)" display="block"><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>X</mi></mrow><mo>+</mo><mi>β</mi></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>α</mi><mn>2</mn></msup><mo>⁢</mo><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS5.SSS1.p1.2" class="ltx_p">Basically, multiplicative constants become squared when they are pulled out, and additive constants disappear (since the variance contributed by a constant is zero).</p>
+</div>
+<div id="S5.SS5.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS5.SSS1.p2.1" class="ltx_p">Furthermore, if <math id="S5.SS5.SSS1.p2.1.m1" class="ltx_Math" alttext="X_{1},\dots,X_{n}" display="inline"><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub></mrow></math> are uncorrelated<span id="footnote14" class="ltx_note ltx_role_footnote"><sup class="ltx_note_mark">14</sup><span class="ltx_note_outer"><span class="ltx_note_content"><sup class="ltx_note_mark">14</sup><span class="ltx_tag ltx_tag_note">14</span>
+We haven’t defined this yet; see the Correlation section below
+</span></span></span>, then</p>
+<table id="S5.Ex146" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex146.m1" class="ltx_Math" alttext="\operatorname{Var}(X_{1}+\dots+X_{n})=\operatorname{Var}(X_{1})+\dots+%
+\operatorname{Var}(X_{n})" display="block"><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>+</mo><mi mathvariant="normal">⋯</mi><mo>+</mo><msub><mi>X</mi><mi>n</mi></msub></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mi mathvariant="normal">⋯</mi><mo>+</mo><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+</section>
+<section id="S5.SS5.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.5.2 </span>Standard deviation</h4>
+
+<div id="S5.SS5.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS5.SSS2.p1.3" class="ltx_p">Variance is a useful notion, but it suffers from that fact the units of variance are not the same as the units of the random variable (again because of the squaring).
+To overcome this problem we can use <span id="S5.SS5.SSS2.p1.3.1" class="ltx_text ltx_font_bold">standard deviation</span>, which is defined as <math id="S5.SS5.SSS2.p1.1.m1" class="ltx_Math" alttext="\sqrt{\operatorname{Var}(X)}" display="inline"><msqrt><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></msqrt></math>.
+The standard deviation of <math id="S5.SS5.SSS2.p1.2.m2" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> has the same units as <math id="S5.SS5.SSS2.p1.3.m3" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math>.</p>
+</div>
+</section>
+</section>
+<section id="S5.SS6" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.6 </span>Covariance</h3>
+
+<div id="S5.SS6.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS6.p1.3" class="ltx_p">Covariance is a measure of the linear relationship between two random variables.
+We denote the covariance between <math id="S5.SS6.p1.1.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and <math id="S5.SS6.p1.2.m2" class="ltx_Math" alttext="Y" display="inline"><mi>Y</mi></math> as <math id="S5.SS6.p1.3.m3" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)" display="inline"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></math>, and it is defined to be</p>
+<table id="S5.Ex147" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex147.m1" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)=\mathbb{E}[(X-\mathbb{E}[X])(Y-\mathbb{E}[Y])]" display="block"><mrow><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>X</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>Y</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>Y</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo stretchy="false">]</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS6.p1.5" class="ltx_p">Note that the outer expectation must be taken over the joint distribution of <math id="S5.SS6.p1.4.m1" class="ltx_Math" alttext="X" display="inline"><mi>X</mi></math> and <math id="S5.SS6.p1.5.m2" class="ltx_Math" alttext="Y" display="inline"><mi>Y</mi></math>.</p>
+</div>
+<div id="S5.SS6.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS6.p2.2" class="ltx_p">Again, the linearity of expectation allows us to rewrite this as</p>
+<table id="S5.Ex148" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex148.m1" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)=\mathbb{E}[XY]-\mathbb{E}[X]\mathbb{E}[Y]" display="block"><mrow><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mrow><mi>X</mi><mo>⁢</mo><mi>Y</mi></mrow><mo stretchy="false">]</mo></mrow></mrow><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>X</mi><mo stretchy="false">]</mo></mrow><mo>⁢</mo><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>Y</mi><mo stretchy="false">]</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS6.p2.1" class="ltx_p">Comparing these formulas to the ones for variance, it is not hard to see that <math id="S5.SS6.p2.1.m1" class="ltx_Math" alttext="\operatorname{Var}(X)=\operatorname{Cov}(X,X)" display="inline"><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.</p>
+</div>
+<div id="S5.SS6.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS6.p3.1" class="ltx_p">A useful property of covariance is that of <span id="S5.SS6.p3.1.1" class="ltx_text ltx_font_bold">bilinearity</span>:</p>
+<table id="Sx1.EGx12" class="ltx_equationgroup ltx_eqn_align ltx_eqn_table">
+
+<tbody id="S5.Ex149"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S5.Ex149.m1" class="ltx_Math" alttext="\displaystyle\operatorname{Cov}(\alpha X+\beta Y,Z)" display="inline"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>X</mi></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mi>Y</mi></mrow></mrow><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex149.m2" class="ltx_Math" alttext="\displaystyle=\alpha\operatorname{Cov}(X,Z)+\beta\operatorname{Cov}(Y,Z)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+<tbody id="S5.Ex150"><tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_td ltx_align_right ltx_eqn_cell"><math id="S5.Ex150.m1" class="ltx_Math" alttext="\displaystyle\operatorname{Cov}(X,\alpha Y+\beta Z)" display="inline"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mi>Y</mi></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mi>Z</mi></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow></math></td>
+<td class="ltx_td ltx_align_left ltx_eqn_cell"><math id="S5.Ex150.m2" class="ltx_Math" alttext="\displaystyle=\alpha\operatorname{Cov}(X,Y)+\beta\operatorname{Cov}(X,Z)" display="inline"><mrow><mi></mi><mo>=</mo><mrow><mrow><mi>α</mi><mo>⁢</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>+</mo><mrow><mi>β</mi><mo>⁢</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Z</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr></tbody>
+</table>
+</div>
+<section id="S5.SS6.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.6.1 </span>Correlation</h4>
+
+<div id="S5.SS6.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS6.SSS1.p1.3" class="ltx_p">Normalizing the covariance gives the <span id="S5.SS6.SSS1.p1.3.1" class="ltx_text ltx_font_bold">correlation</span>:</p>
+<table id="S5.Ex151" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex151.m1" class="ltx_Math" alttext="\rho(X,Y)=\frac{\operatorname{Cov}(X,Y)}{\sqrt{\operatorname{Var}(X)%
+\operatorname{Var}(Y)}}" display="block"><mrow><mrow><mi>ρ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mfrac><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><msqrt><mrow><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo stretchy="false">)</mo></mrow></mrow><mo>⁢</mo><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></msqrt></mfrac></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS6.SSS1.p1.2" class="ltx_p">Correlation also measures the linear relationship between two variables, but unlike covariance always lies between <math id="S5.SS6.SSS1.p1.1.m1" class="ltx_Math" alttext="-1" display="inline"><mrow><mo>-</mo><mn>1</mn></mrow></math> and <math id="S5.SS6.SSS1.p1.2.m2" class="ltx_Math" alttext="1" display="inline"><mn>1</mn></math>.
+</p>
+</div>
+<div id="S5.SS6.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS6.SSS1.p2.3" class="ltx_p">Two variables are said to be <span id="S5.SS6.SSS1.p2.3.1" class="ltx_text ltx_font_bold">uncorrelated</span> if <math id="S5.SS6.SSS1.p2.1.m1" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)=0" display="inline"><mrow><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math> because <math id="S5.SS6.SSS1.p2.2.m2" class="ltx_Math" alttext="\operatorname{Cov}(X,Y)=0" display="inline"><mrow><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math> implies that <math id="S5.SS6.SSS1.p2.3.m3" class="ltx_Math" alttext="\rho(X,Y)=0" display="inline"><mrow><mrow><mi>ρ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mn>0</mn></mrow></math>.
+If two variables are independent, then they are uncorrelated, but the converse does not hold in general.</p>
+</div>
+</section>
+</section>
+<section id="S5.SS7" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.7 </span>Random vectors</h3>
+
+<div id="S5.SS7.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS7.p1.1" class="ltx_p">So far we have been talking about <span id="S5.SS7.p1.1.1" class="ltx_text ltx_font_bold">univariate distributions</span>, that is, distributions of single variables.
+But we can also talk about <span id="S5.SS7.p1.1.2" class="ltx_text ltx_font_bold">multivariate distributions</span> which give distributions of <span id="S5.SS7.p1.1.3" class="ltx_text ltx_font_bold">random vectors</span>:</p>
+<table id="S5.Ex152" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex152.m1" class="ltx_Math" alttext="\mathbf{X}=\begin{bmatrix}X_{1}\\
+\vdots\\
+X_{n}\end{bmatrix}" display="block"><mrow><mi>𝐗</mi><mo>=</mo><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><msub><mi>X</mi><mn>1</mn></msub></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><msub><mi>X</mi><mi>n</mi></msub></mtd></mtr></mtable><mo>]</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS7.p1.2" class="ltx_p">The summarizing quantities we have discussed for single variables have natural generalizations to the multivariate case.</p>
+</div>
+<div id="S5.SS7.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS7.p2.1" class="ltx_p">Expectation of a random vector is simply the expectation applied to each component:</p>
+<table id="S5.Ex153" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex153.m1" class="ltx_Math" alttext="\mathbb{E}[\mathbf{X}]=\begin{bmatrix}\mathbb{E}[X_{1}]\\
+\vdots\\
+\mathbb{E}[X_{n}]\end{bmatrix}" display="block"><mrow><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow><mo>=</mo><mrow><mo>[</mo><mtable displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msub><mi>X</mi><mn>1</mn></msub><mo stretchy="false">]</mo></mrow></mrow></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">]</mo></mrow></mrow></mtd></mtr></mtable><mo>]</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+</div>
+<div id="S5.SS7.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS7.p3.4" class="ltx_p">The variance is generalized by the <span id="S5.SS7.p3.4.1" class="ltx_text ltx_font_bold">covariance matrix</span>:</p>
+<table id="S5.Ex154" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex154.m1" class="ltx_Math" alttext="\mathbf{\Sigma}=\mathbb{E}[(\mathbf{X}-\mathbb{E}[\mathbf{X}])(\mathbf{X}-%
+\mathbb{E}[\mathbf{X}])^{\!\top\!}]=\begin{bmatrix}\operatorname{Var}(X_{1})&amp;%
+\operatorname{Cov}(X_{1},X_{2})&amp;\ldots&amp;\operatorname{Cov}(X_{1},X_{n})\\
+\operatorname{Cov}(X_{2},X_{1})&amp;\operatorname{Var}(X_{2})&amp;\ldots&amp;\operatorname%
+{Cov}(X_{2},X_{n})\\
+\vdots&amp;\vdots&amp;\ddots&amp;\vdots\\
+\operatorname{Cov}(X_{n},X_{1})&amp;\operatorname{Cov}(X_{n},X_{2})&amp;\ldots&amp;%
+\operatorname{Var}(X_{n})\end{bmatrix}" display="block"><mrow><mi>𝚺</mi><mo>=</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo stretchy="false">]</mo></mrow></mrow><mo>=</mo><mrow><mo>[</mo><mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt"><mtr><mtd columnalign="center"><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><msub><mi>X</mi><mn>2</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mtd></mtr><mtr><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>2</mn></msub><mo>,</mo><msub><mi>X</mi><mn>1</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>2</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mn>2</mn></msub><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mtd></mtr><mtr><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋱</mi></mtd><mtd columnalign="center"><mi mathvariant="normal">⋮</mi></mtd></mtr><mtr><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>n</mi></msub><mo>,</mo><msub><mi>X</mi><mn>1</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>n</mi></msub><mo>,</mo><msub><mi>X</mi><mn>2</mn></msub><mo stretchy="false">)</mo></mrow></mrow></mtd><mtd columnalign="center"><mi mathvariant="normal">…</mi></mtd><mtd columnalign="center"><mrow><mi>Var</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>n</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mtd></mtr></mtable><mo>]</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS7.p3.2" class="ltx_p">That is, <math id="S5.SS7.p3.1.m1" class="ltx_Math" alttext="\Sigma_{ij}=\operatorname{Cov}(X_{i},X_{j})" display="inline"><mrow><msub><mi mathvariant="normal">Σ</mi><mrow><mi>i</mi><mo>⁢</mo><mi>j</mi></mrow></msub><mo>=</mo><mrow><mi>Cov</mi><mo>⁡</mo><mrow><mo stretchy="false">(</mo><msub><mi>X</mi><mi>i</mi></msub><mo>,</mo><msub><mi>X</mi><mi>j</mi></msub><mo stretchy="false">)</mo></mrow></mrow></mrow></math>.
+Since covariance is symmetric in its arguments, the covariance matrix is also symmetric.
+It’s also positive semi-definite: for any <math id="S5.SS7.p3.2.m2" class="ltx_Math" alttext="\mathbf{x}" display="inline"><mi>𝐱</mi></math>,</p>
+<table id="S5.Ex155" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex155.m1" class="ltx_Math" alttext="\mathbf{x}^{\!\top\!}\mathbf{\Sigma}\mathbf{x}=\mathbf{x}^{\!\top\!}\mathbb{E}%
+[(\mathbf{X}-\mathbb{E}[\mathbf{X}])(\mathbf{X}-\mathbb{E}[\mathbf{X}])^{\!%
+\top\!}]\mathbf{x}=\mathbb{E}[\mathbf{x}^{\!\top\!}(\mathbf{X}-\mathbb{E}[%
+\mathbf{X}])(\mathbf{X}-\mathbb{E}[\mathbf{X}])^{\!\top\!}\mathbf{x}]=\mathbb{%
+E}[((\mathbf{X}-\mathbb{E}[\mathbf{X}])^{\!\top\!}\mathbf{x})^{2}]\geq 0" display="block"><mrow><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝚺</mi><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mrow><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup></mrow><mo stretchy="false">]</mo></mrow><mo>⁢</mo><mi>𝐱</mi></mrow><mo>=</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">]</mo></mrow></mrow><mo>=</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><msup><mrow><mo stretchy="false">(</mo><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐗</mi><mo>-</mo><mrow><mi>𝔼</mi><mo>⁢</mo><mrow><mo stretchy="false">[</mo><mi>𝐗</mi><mo stretchy="false">]</mo></mrow></mrow></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐱</mi></mrow><mo stretchy="false">)</mo></mrow><mn>2</mn></msup><mo stretchy="false">]</mo></mrow></mrow><mo>≥</mo><mn>0</mn></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS7.p3.3" class="ltx_p">The inverse of the covariance matrix, <math id="S5.SS7.p3.3.m1" class="ltx_Math" alttext="\mathbf{\Sigma}^{-1}" display="inline"><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math>, is sometimes called the <span id="S5.SS7.p3.3.1" class="ltx_text ltx_font_bold">precision matrix</span>.
+</p>
+</div>
+</section>
+<section id="S5.SS8" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.8 </span>Estimation of Parameters</h3>
+
+<div id="S5.SS8.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS8.p1.1" class="ltx_p">Now we get into some basic topics from statistics.
+We make some assumptions about our problem by prescribing a <span id="S5.SS8.p1.1.1" class="ltx_text ltx_font_bold">parametric</span> model (e.g. a distribution that describes how the data were generated), then we fit the parameters of the model to the data.
+How do we choose the values of the parameters?</p>
+</div>
+<section id="S5.SS8.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.8.1 </span>Maximum likelihood estimation</h4>
+
+<div id="S5.SS8.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS8.SSS1.p1.2" class="ltx_p">A common way to fit parameters is <span id="S5.SS8.SSS1.p1.2.1" class="ltx_text ltx_font_bold">maximum likelihood estimation</span> (MLE).
+The basic principle of MLE is to choose values that “explain” the data best by maximizing the probability/density of the data we’ve seen as a function of the parameters.
+Suppose we have random variables <math id="S5.SS8.SSS1.p1.1.m1" class="ltx_Math" alttext="X_{1},\dots,X_{n}" display="inline"><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub></mrow></math> and corresponding observations <math id="S5.SS8.SSS1.p1.2.m2" class="ltx_Math" alttext="x_{1},\dots,x_{n}" display="inline"><mrow><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></math>.
+Then</p>
+<table id="S5.Ex156" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex156.m1" class="ltx_Math" alttext="\hat{\mathbf{\theta}}_{\textsc{mle}}=\operatorname*{arg\,max}_{\mathbf{\theta}%
+}\mathcal{L}(\mathbf{\theta})" display="block"><mrow><msub><mover accent="true"><mi>θ</mi><mo stretchy="false">^</mo></mover><mtext class="ltx_font_smallcaps" mathvariant="normal">mle</mtext></msub><mo>=</mo><mrow><mrow><munder><mrow><mpadded width="+1.7pt"><mi>arg</mi></mpadded><mo movablelimits="false">⁢</mo><mi>max</mi></mrow><mi>θ</mi></munder><mo>⁡</mo><mi class="ltx_font_mathcaligraphic">ℒ</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS1.p1.3" class="ltx_p">where <math id="S5.SS8.SSS1.p1.3.m1" class="ltx_Math" alttext="\mathcal{L}" display="inline"><mi class="ltx_font_mathcaligraphic">ℒ</mi></math> is the <span id="S5.SS8.SSS1.p1.3.1" class="ltx_text ltx_font_bold">likelihood function</span></p>
+<table id="S5.Ex157" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex157.m1" class="ltx_Math" alttext="\mathcal{L}(\mathbf{\theta})=p(x_{1},\dots,x_{n};\mathbf{\theta})" display="block"><mrow><mrow><mi class="ltx_font_mathcaligraphic">ℒ</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>x</mi><mi>n</mi></msub><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS1.p1.4" class="ltx_p">Often, we assume that <math id="S5.SS8.SSS1.p1.4.m1" class="ltx_Math" alttext="X_{1},\dots,X_{n}" display="inline"><mrow><msub><mi>X</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>X</mi><mi>n</mi></msub></mrow></math> are i.i.d. Then we can write</p>
+<table id="S5.Ex158" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex158.m1" class="ltx_Math" alttext="p(x_{1},\dots,x_{n};\theta)=\prod_{i=1}^{n}p(x_{i};\mathbf{\theta})" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>x</mi><mi>n</mi></msub><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mi>i</mi></msub><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS1.p1.7" class="ltx_p">At this point, it is usually convenient to take logs, giving rise to the <span id="S5.SS8.SSS1.p1.7.1" class="ltx_text ltx_font_bold">log-likelihood</span></p>
+<table id="S5.Ex159" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex159.m1" class="ltx_Math" alttext="\log\mathcal{L}(\mathbf{\theta})=\sum_{i=1}^{n}\log p(x_{i};\mathbf{\theta})" display="block"><mrow><mrow><mrow><mi>log</mi><mo>⁡</mo><mi class="ltx_font_mathcaligraphic">ℒ</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><mrow><mi>log</mi><mo>⁡</mo><mi>p</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mi>i</mi></msub><mo>;</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS1.p1.6" class="ltx_p">This is a valid operation because the probabilities/densities are assumed to be positive, and since log is a monotonically increasing function, it preserves ordering.
+In other words, any maximizer of <math id="S5.SS8.SSS1.p1.5.m1" class="ltx_Math" alttext="\log\mathcal{L}" display="inline"><mrow><mi>log</mi><mo>⁡</mo><mi class="ltx_font_mathcaligraphic">ℒ</mi></mrow></math> will also maximize <math id="S5.SS8.SSS1.p1.6.m2" class="ltx_Math" alttext="\mathcal{L}" display="inline"><mi class="ltx_font_mathcaligraphic">ℒ</mi></math>.</p>
+</div>
+<div id="S5.SS8.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS8.SSS1.p2.2" class="ltx_p">For some distributions, it is possible to analytically solve for the maximum likelihood estimator.
+If <math id="S5.SS8.SSS1.p2.1.m1" class="ltx_Math" alttext="\log\mathcal{L}" display="inline"><mrow><mi>log</mi><mo>⁡</mo><mi class="ltx_font_mathcaligraphic">ℒ</mi></mrow></math> is differentiable, setting the derivatives to zero and trying to solve for <math id="S5.SS8.SSS1.p2.2.m2" class="ltx_Math" alttext="\mathbf{\theta}" display="inline"><mi>θ</mi></math> is a good place to start.</p>
+</div>
+</section>
+<section id="S5.SS8.SSS2" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.8.2 </span>Maximum a posteriori estimation</h4>
+
+<div id="S5.SS8.SSS2.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS8.SSS2.p1.1" class="ltx_p">A more Bayesian way to fit parameters is through <span id="S5.SS8.SSS2.p1.1.1" class="ltx_text ltx_font_bold">maximum a posteriori estimation</span> (MAP).
+In this technique we assume that the parameters are a random variable, and we specify a prior distribution <math id="S5.SS8.SSS2.p1.1.m1" class="ltx_Math" alttext="p(\mathbf{\theta})" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow></math>.
+Then we can employ Bayes’ rule to compute the posterior distribution of the parameters given the observed data:</p>
+<table id="S5.Ex160" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex160.m1" class="ltx_Math" alttext="p(\mathbf{\theta}|x_{1},\dots,x_{n})\propto p(\mathbf{\theta})p(x_{1},\dots,x_%
+{n}|\mathbf{\theta})" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>θ</mi><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mrow><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><msub><mi>x</mi><mi>n</mi></msub></mrow></mrow><mo stretchy="false">)</mo></mrow></mrow><mo>∝</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><mrow><msub><mi>x</mi><mi>n</mi></msub><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>θ</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS2.p1.2" class="ltx_p">Computing the normalizing constant is often intractable, because it involves integrating over the parameter space, which may be very high-dimensional.
+Fortunately, if we just want the MAP estimate, we don’t care about the normalizing constant!
+It does not affect which values of <math id="S5.SS8.SSS2.p1.2.m1" class="ltx_Math" alttext="\mathbf{\theta}" display="inline"><mi>θ</mi></math> maximize the posterior.
+So we have</p>
+<table id="S5.Ex161" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex161.m1" class="ltx_Math" alttext="\hat{\mathbf{\theta}}_{\textsc{map}}=\operatorname*{arg\,max}_{\mathbf{\theta}%
+}p(\mathbf{\theta})p(x_{1},\dots,x_{n}|\mathbf{\theta})" display="block"><mrow><msub><mover accent="true"><mi>θ</mi><mo stretchy="false">^</mo></mover><mtext class="ltx_font_smallcaps" mathvariant="normal">map</mtext></msub><mo>=</mo><mrow><mrow><munder><mrow><mpadded width="+1.7pt"><mi>arg</mi></mpadded><mo movablelimits="false">⁢</mo><mi>max</mi></mrow><mi>θ</mi></munder><mo>⁡</mo><mi>p</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow><mo>⁢</mo><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><msub><mi>x</mi><mn>1</mn></msub><mo>,</mo><mi mathvariant="normal">…</mi><mo>,</mo><mrow><msub><mi>x</mi><mi>n</mi></msub><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>θ</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS2.p1.3" class="ltx_p">Again, if we assume the observations are i.i.d., then we can express this in the equivalent, and possibly friendlier, form</p>
+<table id="S5.Ex162" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex162.m1" class="ltx_Math" alttext="\hat{\mathbf{\theta}}_{\textsc{map}}=\operatorname*{arg\,max}_{\mathbf{\theta}%
+}\left(\log p(\mathbf{\theta})+\sum_{i=1}^{n}\log p(x_{i}|\mathbf{\theta})\right)" display="block"><mrow><msub><mover accent="true"><mi>θ</mi><mo stretchy="false">^</mo></mover><mtext class="ltx_font_smallcaps" mathvariant="normal">map</mtext></msub><mo>=</mo><mrow><munder><mrow><mpadded width="+1.7pt"><mi>arg</mi></mpadded><mo movablelimits="false">⁢</mo><mi>max</mi></mrow><mi>θ</mi></munder><mo>⁡</mo><mrow><mo>(</mo><mrow><mrow><mrow><mi>log</mi><mo>⁡</mo><mi>p</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>θ</mi><mo stretchy="false">)</mo></mrow></mrow><mo>+</mo><mrow><munderover><mo largeop="true" movablelimits="false" symmetric="true">∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mrow><mrow><mi>log</mi><mo>⁡</mo><mi>p</mi></mrow><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msub><mi>x</mi><mi>i</mi></msub><mo lspace="2.5pt" rspace="2.5pt" stretchy="false">|</mo><mi>θ</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></mrow><mo>)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS8.SSS2.p1.4" class="ltx_p">A particularly nice case is when the prior is chosen carefully such that the posterior comes from the same family as the prior.
+In this case the prior is called a <span id="S5.SS8.SSS2.p1.4.1" class="ltx_text ltx_font_bold">conjugate prior</span>.
+For example, if the likelihood is binomial and the prior is beta, the posterior is also beta.
+There are many conjugate priors; the reader may find this <a href="https://en.wikipedia.org/wiki/Conjugate_prior#Table_of_conjugate_distributions" title="" class="ltx_ref ltx_href">table of conjugate priors</a> useful.</p>
+</div>
+</section>
+</section>
+<section id="S5.SS9" class="ltx_subsection">
+<h3 class="ltx_title ltx_title_subsection">
+<span class="ltx_tag ltx_tag_subsection">5.9 </span>The Gaussian distribution</h3>
+
+<div id="S5.SS9.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS9.p1.2" class="ltx_p">There are many distributions, but one of particular importance is the <span id="S5.SS9.p1.2.1" class="ltx_text ltx_font_bold">Gaussian distribution</span>, also known as the <span id="S5.SS9.p1.2.2" class="ltx_text ltx_font_bold">normal distribution</span>.
+It is a continuous distribution, parameterized by its mean <math id="S5.SS9.p1.1.m1" class="ltx_Math" alttext="\bm{\mu}\in\mathbb{R}^{d}" display="inline"><mrow><mi>𝝁</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup></mrow></math> and positive-definite covariance matrix <math id="S5.SS9.p1.2.m2" class="ltx_Math" alttext="\mathbf{\Sigma}\in\mathbb{R}^{d\times d}" display="inline"><mrow><mi>𝚺</mi><mo>∈</mo><msup><mi>ℝ</mi><mrow><mi>d</mi><mo>×</mo><mi>d</mi></mrow></msup></mrow></math>, with density</p>
+<table id="S5.Ex163" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex163.m1" class="ltx_Math" alttext="p(\mathbf{x};\bm{\mu},\mathbf{\Sigma})=\frac{1}{\sqrt{(2\pi)^{d}\det(\mathbf{%
+\Sigma})}}\exp\left(-\frac{1}{2}(\mathbf{x}-\bm{\mu})^{\!\top\!}\mathbf{\Sigma%
+}^{-1}(\mathbf{x}-\bm{\mu})\right)" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>;</mo><mi>𝝁</mi><mo>,</mo><mi>𝚺</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mfrac><mn>1</mn><msqrt><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mn>2</mn><mo>⁢</mo><mi>π</mi></mrow><mo stretchy="false">)</mo></mrow><mi>d</mi></msup><mo>⁢</mo><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝚺</mi><mo>)</mo></mrow></mrow></mrow></msqrt></mfrac><mo>⁢</mo><mrow><mi>exp</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mo>-</mo><mrow><mfrac><mn>1</mn><mn>2</mn></mfrac><mo>⁢</mo><msup><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝝁</mi></mrow><mo stretchy="false">)</mo></mrow><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝝁</mi></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow><mo>)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS9.p1.3" class="ltx_p">Note that in the special case <math id="S5.SS9.p1.3.m1" class="ltx_Math" alttext="d=1" display="inline"><mrow><mi>d</mi><mo>=</mo><mn>1</mn></mrow></math>, the density is written in the more recognizable form</p>
+<table id="S5.Ex164" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex164.m1" class="ltx_Math" alttext="p(x;\mu,\sigma^{2})=\frac{1}{\sqrt{2\pi\sigma^{2}}}\exp\left(-\frac{(x-\mu)^{2%
+}}{2\sigma^{2}}\right)" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>x</mi><mo>;</mo><mi>μ</mi><mo>,</mo><msup><mi>σ</mi><mn>2</mn></msup><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mfrac><mn>1</mn><msqrt><mrow><mn>2</mn><mo>⁢</mo><mi>π</mi><mo>⁢</mo><msup><mi>σ</mi><mn>2</mn></msup></mrow></msqrt></mfrac><mo>⁢</mo><mrow><mi>exp</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mo>-</mo><mfrac><msup><mrow><mo stretchy="false">(</mo><mrow><mi>x</mi><mo>-</mo><mi>μ</mi></mrow><mo stretchy="false">)</mo></mrow><mn>2</mn></msup><mrow><mn>2</mn><mo>⁢</mo><msup><mi>σ</mi><mn>2</mn></msup></mrow></mfrac></mrow><mo>)</mo></mrow></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS9.p1.7" class="ltx_p">We write <math id="S5.SS9.p1.4.m1" class="ltx_Math" alttext="\mathbf{X}\sim\mathcal{N}(\bm{\mu},\mathbf{\Sigma})" display="inline"><mrow><mi>𝐗</mi><mo>∼</mo><mrow><mi class="ltx_font_mathcaligraphic">𝒩</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝝁</mi><mo>,</mo><mi>𝚺</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> to denote that <math id="S5.SS9.p1.5.m2" class="ltx_Math" alttext="\mathbf{X}" display="inline"><mi>𝐗</mi></math> is normally distributed with mean <math id="S5.SS9.p1.6.m3" class="ltx_Math" alttext="\bm{\mu}" display="inline"><mi>𝝁</mi></math> and variance <math id="S5.SS9.p1.7.m4" class="ltx_Math" alttext="\mathbf{\Sigma}" display="inline"><mi>𝚺</mi></math>.</p>
+</div>
+<section id="S5.SS9.SSS1" class="ltx_subsubsection">
+<h4 class="ltx_title ltx_title_subsubsection">
+<span class="ltx_tag ltx_tag_subsubsection">5.9.1 </span>The geometry of multivariate Gaussians</h4>
+
+<div id="S5.SS9.SSS1.p1" class="ltx_para ltx_noindent">
+<p id="S5.SS9.SSS1.p1.1" class="ltx_p">The geometry of the multivariate Gaussian density is intimately related to the geometry of positive definite quadratic forms, so make sure the material in that section is well-understood before tackling this section.</p>
+</div>
+<div id="S5.SS9.SSS1.p2" class="ltx_para ltx_noindent">
+<p id="S5.SS9.SSS1.p2.4" class="ltx_p">First observe that the p.d.f. of the multivariate Gaussian can be rewritten as</p>
+<table id="S5.Ex165" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex165.m1" class="ltx_Math" alttext="p(\mathbf{x};\bm{\mu},\mathbf{\Sigma})=g(\tilde{\mathbf{x}}^{\!\top\!}\mathbf{%
+\Sigma}^{-1}\tilde{\mathbf{x}})" display="block"><mrow><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>;</mo><mi>𝝁</mi><mo>,</mo><mi>𝚺</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mrow><msup><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow><mo stretchy="false">)</mo></mrow></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS9.SSS1.p2.3" class="ltx_p">where <math id="S5.SS9.SSS1.p2.1.m1" class="ltx_Math" alttext="\tilde{\mathbf{x}}=\mathbf{x}-\bm{\mu}" display="inline"><mrow><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo>=</mo><mrow><mi>𝐱</mi><mo>-</mo><mi>𝝁</mi></mrow></mrow></math> and <math id="S5.SS9.SSS1.p2.2.m2" class="ltx_Math" alttext="g(z)=[(2\pi)^{d}\det(\mathbf{\Sigma})]^{-\frac{1}{2}}\exp\left(-\frac{z}{2}\right)" display="inline"><mrow><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>z</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mrow><mo stretchy="false">[</mo><mrow><msup><mrow><mo stretchy="false">(</mo><mrow><mn>2</mn><mo>⁢</mo><mi>π</mi></mrow><mo stretchy="false">)</mo></mrow><mi>d</mi></msup><mo>⁢</mo><mrow><mi>det</mi><mo>⁡</mo><mrow><mo>(</mo><mi>𝚺</mi><mo>)</mo></mrow></mrow></mrow><mo stretchy="false">]</mo></mrow><mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow></msup><mo>⁢</mo><mrow><mi>exp</mi><mo>⁡</mo><mrow><mo>(</mo><mrow><mo>-</mo><mfrac><mi>z</mi><mn>2</mn></mfrac></mrow><mo>)</mo></mrow></mrow></mrow></mrow></math>.
+Writing the density in this way, we see that after shifting by the mean <math id="S5.SS9.SSS1.p2.3.m3" class="ltx_Math" alttext="\bm{\mu}" display="inline"><mi>𝝁</mi></math>, the density is really just a simple function of its precision matrix’s quadratic form.</p>
+</div>
+<div id="S5.SS9.SSS1.p3" class="ltx_para ltx_noindent">
+<p id="S5.SS9.SSS1.p3.13" class="ltx_p">Here is a key observation: this function <math id="S5.SS9.SSS1.p3.1.m1" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is <span id="S5.SS9.SSS1.p3.13.1" class="ltx_text ltx_font_bold">strictly monotonically decreasing</span> in its argument.
+That is, <math id="S5.SS9.SSS1.p3.2.m2" class="ltx_Math" alttext="g(a)&gt;g(b)" display="inline"><mrow><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>a</mi><mo stretchy="false">)</mo></mrow></mrow><mo>&gt;</mo><mrow><mi>g</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>b</mi><mo stretchy="false">)</mo></mrow></mrow></mrow></math> whenever <math id="S5.SS9.SSS1.p3.3.m3" class="ltx_Math" alttext="a&lt;b" display="inline"><mrow><mi>a</mi><mo>&lt;</mo><mi>b</mi></mrow></math>.
+Therefore, small values of <math id="S5.SS9.SSS1.p3.4.m4" class="ltx_Math" alttext="\tilde{\mathbf{x}}^{\!\top\!}\mathbf{\Sigma}^{-1}\tilde{\mathbf{x}}" display="inline"><mrow><msup><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow></math> (which generally correspond to points where <math id="S5.SS9.SSS1.p3.5.m5" class="ltx_Math" alttext="\tilde{\mathbf{x}}" display="inline"><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></math> is closer to <math id="S5.SS9.SSS1.p3.6.m6" class="ltx_Math" alttext="\mathbf{0}" display="inline"><mn>𝟎</mn></math>, i.e. <math id="S5.SS9.SSS1.p3.7.m7" class="ltx_Math" alttext="\mathbf{x}\approx\bm{\mu}" display="inline"><mrow><mi>𝐱</mi><mo>≈</mo><mi>𝝁</mi></mrow></math>) have relatively high probability densities, and vice-versa.
+Furthermore, because <math id="S5.SS9.SSS1.p3.8.m8" class="ltx_Math" alttext="g" display="inline"><mi>g</mi></math> is <span id="S5.SS9.SSS1.p3.13.2" class="ltx_text ltx_font_italic">strictly</span> monotonic, it is injective, so the <math id="S5.SS9.SSS1.p3.9.m9" class="ltx_Math" alttext="c" display="inline"><mi>c</mi></math>-isocontours of <math id="S5.SS9.SSS1.p3.10.m10" class="ltx_Math" alttext="p(\mathbf{x};\bm{\mu},\mathbf{\Sigma})" display="inline"><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>;</mo><mi>𝝁</mi><mo>,</mo><mi>𝚺</mi><mo stretchy="false">)</mo></mrow></mrow></math> are the <math id="S5.SS9.SSS1.p3.11.m11" class="ltx_Math" alttext="g^{-1}(c)" display="inline"><mrow><msup><mi>g</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>c</mi><mo stretchy="false">)</mo></mrow></mrow></math>-isocontours of the function <math id="S5.SS9.SSS1.p3.12.m12" class="ltx_Math" alttext="\mathbf{x}\mapsto\tilde{\mathbf{x}}^{\!\top\!}\mathbf{\Sigma}^{-1}\tilde{%
+\mathbf{x}}" display="inline"><mrow><mi>𝐱</mi><mo>↦</mo><mrow><msup><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow></mrow></math>.
+That is, for any <math id="S5.SS9.SSS1.p3.13.m13" class="ltx_Math" alttext="c" display="inline"><mi>c</mi></math>,</p>
+<table id="S5.Ex166" class="ltx_equation ltx_eqn_table">
+
+<tr class="ltx_equation ltx_eqn_row ltx_align_baseline">
+<td class="ltx_eqn_cell ltx_eqn_center_padleft"></td>
+<td class="ltx_eqn_cell ltx_align_center"><math id="S5.Ex166.m1" class="ltx_Math" alttext="\{\mathbf{x}\in\mathbb{R}^{d}\mathrel{\mathop{:}}p(\mathbf{x};\bm{\mu},\mathbf%
+{\Sigma})=c\}=\{\mathbf{x}\in\mathbb{R}^{d}\mathrel{\mathop{:}}\tilde{\mathbf{%
+x}}^{\!\top\!}\mathbf{\Sigma}^{-1}\tilde{\mathbf{x}}=g^{-1}(c)\}" display="block"><mrow><mrow><mo stretchy="false">{</mo><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo movablelimits="false">:</mo><mrow><mi>p</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo>;</mo><mi>𝝁</mi><mo>,</mo><mi>𝚺</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mi>c</mi></mrow><mo stretchy="false">}</mo></mrow><mo>=</mo><mrow><mo stretchy="false">{</mo><mrow><mi>𝐱</mi><mo>∈</mo><msup><mi>ℝ</mi><mi>d</mi></msup><mo movablelimits="false">:</mo><mrow><msup><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mover accent="true"><mi>𝐱</mi><mo stretchy="false">~</mo></mover></mrow><mo>=</mo><mrow><msup><mi>g</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>c</mi><mo stretchy="false">)</mo></mrow></mrow></mrow><mo stretchy="false">}</mo></mrow></mrow></math></td>
+<td class="ltx_eqn_cell ltx_eqn_center_padright"></td>
+</tr>
+</table>
+<p id="S5.SS9.SSS1.p3.14" class="ltx_p">In words, these functions have the same isocontours but different isovalues.</p>
+</div>
+<div id="S5.SS9.SSS1.p4" class="ltx_para ltx_noindent">
+<p id="S5.SS9.SSS1.p4.5" class="ltx_p">Recall the executive summary of the geometry of positive definite quadratic forms: the isocontours of <math id="S5.SS9.SSS1.p4.1.m1" class="ltx_Math" alttext="f(\mathbf{x})=\mathbf{x}^{\!\top\!}\mathbf{A}\mathbf{x}" display="inline"><mrow><mrow><mi>f</mi><mo>⁢</mo><mrow><mo stretchy="false">(</mo><mi>𝐱</mi><mo stretchy="false">)</mo></mrow></mrow><mo>=</mo><mrow><msup><mi>𝐱</mi><mo lspace="0.8pt" rspace="0.8pt">⊤</mo></msup><mo>⁢</mo><mi>𝐀𝐱</mi></mrow></mrow></math> are ellipsoids such that the axes point in the directions of the eigenvectors of <math id="S5.SS9.SSS1.p4.2.m2" class="ltx_Math" alttext="\mathbf{A}" display="inline"><mi>𝐀</mi></math>, and the lengths of these axes are proportional to the inverse square roots of the corresponding eigenvalues.
+Therefore in this case, the isocontours of the density are ellipsoids (centered at <math id="S5.SS9.SSS1.p4.3.m3" class="ltx_Math" alttext="\bm{\mu}" display="inline"><mi>𝝁</mi></math>) with axis lengths proportional to the inverse square roots of the eigenvalues of <math id="S5.SS9.SSS1.p4.4.m4" class="ltx_Math" alttext="\mathbf{\Sigma}^{-1}" display="inline"><msup><mi>𝚺</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math>, or equivalently, the square roots of the eigenvalues of <math id="S5.SS9.SSS1.p4.5.m5" class="ltx_Math" alttext="\mathbf{\Sigma}" display="inline"><mi>𝚺</mi></math>.</p>
+</div>
+<div class="ltx_pagination ltx_role_newpage"></div>
+</section>
+</section>
+</section>
+<section id="Sx1" class="ltx_section">
+<h2 class="ltx_title ltx_title_section">Acknowledgements</h2>
+
+<div id="Sx1.p1" class="ltx_para ltx_noindent">
+<p id="Sx1.p1.1" class="ltx_p">The author would like to thank Michael Franco for suggested clarifications, and Chinmoy Saayujya for catching a typo.</p>
+</div>
+</section>
+<section id="bib" class="ltx_bibliography">
+<h2 class="ltx_title ltx_title_bibliography">References</h2>
+
+<ul id="bib.L1" class="ltx_biblist">
+<li id="bib.bib3" class="ltx_bibitem ltx_bib_book">
+<span class="ltx_tag ltx_bib_key ltx_role_refnum ltx_tag_bibitem">[1]</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_author">J. Nocedal and S. J. Wright</span><span class="ltx_text ltx_bib_year"> (2006)</span>
+</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_title">Numerical optimization</span>.
+</span>
+<span class="ltx_bibblock"> <span class="ltx_text ltx_bib_publisher">Springer Science+Business Media</span>, <span class="ltx_text ltx_bib_place">New York</span>.
+</span>
+<span class="ltx_bibblock ltx_bib_cited">Cited by: <a href="#S4.SS6.p1.1" title="4.6 Taylor’s theorem ‣ 4 Calculus and Optimization ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_tag">§4.6</span></a>.
+</span>
+</li>
+<li id="bib.bib4" class="ltx_bibitem ltx_bib_book">
+<span class="ltx_tag ltx_bib_key ltx_role_refnum ltx_tag_bibitem">[2]</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_author">J. Pitman</span><span class="ltx_text ltx_bib_year"> (1993)</span>
+</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_title">Probability</span>.
+</span>
+<span class="ltx_bibblock"> <span class="ltx_text ltx_bib_publisher">Springer-Verlag</span>, <span class="ltx_text ltx_bib_place">New York</span>.
+</span>
+<span class="ltx_bibblock ltx_bib_cited">Cited by: <a href="#S5.SS2.p3.3" title="5.2 Random variables ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_tag">§5.2</span></a>.
+</span>
+</li>
+<li id="bib.bib5" class="ltx_bibitem ltx_bib_book">
+<span class="ltx_tag ltx_bib_key ltx_role_refnum ltx_tag_bibitem">[3]</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_author">J. S. Rosenthal</span><span class="ltx_text ltx_bib_year"> (2006)</span>
+</span>
+<span class="ltx_bibblock"><span class="ltx_text ltx_bib_title">A first look at rigorous probability theory (second edition)</span>.
+</span>
+<span class="ltx_bibblock"> <span class="ltx_text ltx_bib_publisher">World Scientific Publishing</span>, <span class="ltx_text ltx_bib_place">Singapore</span>.
+</span>
+<span class="ltx_bibblock ltx_bib_cited">Cited by: <a href="#footnote7" title="footnote 7 ‣ 5.1 Basics ‣ 5 Probability ‣ Mathematics for Machine Learning" class="ltx_ref"><span class="ltx_text ltx_ref_tag">footnote 7</span></a>.
+</span>
+</li>
+</ul>
+</section>
+<div id="p1" class="ltx_para ltx_noindent">
+<p id="p1.1" class="ltx_p"></p>
+</div>
+</article>
+</div>
+<footer class="ltx_page_footer">
+<div class="ltx_page_logo">Generated  on Tue Dec 21 16:14:08 2021 by <a href="http://dlmf.nist.gov/LaTeXML/">LaTeXML <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==" alt="[LOGO]"></a>
+</div></footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Hi!

Thank you for making such a great resource openly available. I ran a quick experiment generating an HTML5 version of it using latexml, and I think you may enjoy it.

Generated via:
```
latexmlc math4ml.tex --destination=index.html --includestyles 
  --preload=[ids,magnify=2,zoomout=2]latexml.sty  --pmml --nodefaultresources 
  --css=https://cdn.jsdelivr.net/gh/dginev/ar5iv-css@0.5.6/css/ar5iv.min.css
  --javascript=LaTeXML-maybeMathjax.js
```

and deployed via gh-pages once pushed live, as standard. You can preview the outcome here:
https://dginev.github.io/math4ml/

Thanks again for publishing in the open!